### PR TITLE
feat(memberships): add memberships vertical slice with API layer

### DIFF
--- a/drizzle/migrations/0001_add_memberships_indexes.sql
+++ b/drizzle/migrations/0001_add_memberships_indexes.sql
@@ -1,0 +1,8 @@
+-- Add indexes for common membership queries
+CREATE INDEX IF NOT EXISTS idx_memberships_profile ON memberships(profile_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_memberships_community ON memberships(community_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_memberships_community_role ON memberships(community_id, role);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_memberships_community_status ON memberships(community_id, status);

--- a/src/app/api/communities/[slug]/members/[profileId]/route.test.ts
+++ b/src/app/api/communities/[slug]/members/[profileId]/route.test.ts
@@ -108,10 +108,14 @@ mock.module("@/features/memberships", () => ({
   AlreadyMemberError: class extends Error {},
   BannedUserError: class extends Error {},
   CannotModifyOwnerError: class extends Error {},
+  DatabaseError: class extends Error {},
   InvalidRoleAssignmentError: class extends Error {},
+  MembershipCreationFailedError: class extends Error {},
+  MembershipDeleteFailedError: class extends Error {},
   MembershipNotFoundError: class extends Error {},
   NotMemberError: class extends Error {},
   OwnerCannotLeaveError: class extends Error {},
+  OwnershipTransferFailedError: class extends Error {},
 }));
 
 // Import routes after mocking

--- a/src/app/api/communities/[slug]/members/[profileId]/route.test.ts
+++ b/src/app/api/communities/[slug]/members/[profileId]/route.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { NextRequest } from "next/server";
+
+// Mock user type
+type MockUser = { id: string; email: string } | null;
+const mockUser: MockUser = { id: "user-123", email: "test@example.com" };
+
+type Membership = {
+  membershipId: string;
+  communityId: string;
+  profileId: string;
+  role: "owner" | "co_owner" | "admin" | "moderator" | "member";
+  status: "active" | "pending" | "banned";
+  invitedByProfileId: string | null;
+  joinedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+const mockMembership: Membership = {
+  membershipId: "membership-123",
+  communityId: "community-123",
+  profileId: "profile-456",
+  role: "member",
+  status: "active",
+  invitedByProfileId: null,
+  joinedAt: new Date("2024-01-01"),
+  createdAt: new Date("2024-01-01"),
+  updatedAt: new Date("2024-01-01"),
+};
+
+// InsufficientPermissionsError class for testing
+class InsufficientPermissionsError extends Error {
+  readonly code = "INSUFFICIENT_PERMISSIONS";
+  readonly statusCode = 403;
+  constructor(action: string) {
+    super(`Insufficient permissions to: ${action}`);
+    this.name = "InsufficientPermissionsError";
+  }
+}
+
+// Mock Supabase auth
+const mockGetUser = mock<() => Promise<{ data: { user: MockUser }; error: null }>>(() =>
+  Promise.resolve({ data: { user: mockUser }, error: null }),
+);
+mock.module("@/core/supabase/server", () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: mockGetUser },
+    }),
+}));
+
+// Mock communities service
+const mockGetCommunityBySlug = mock(() =>
+  Promise.resolve({ communityId: "community-123", visibility: "public" }),
+);
+mock.module("@/features/communities", () => ({
+  getCommunityBySlug: mockGetCommunityBySlug,
+  CommunityError: class extends Error {},
+}));
+
+// Mock profiles service
+const mockGetProfileByUserId = mock(() => Promise.resolve({ profileId: "profile-123" }));
+mock.module("@/features/profiles", () => ({
+  getProfileByUserId: mockGetProfileByUserId,
+  ProfileError: class extends Error {},
+}));
+
+// Mock memberships service
+const mockGetMembershipByProfileAndCommunity = mock(() => Promise.resolve(mockMembership));
+const mockUpdateMembership = mock(() => Promise.resolve({ ...mockMembership, role: "moderator" }));
+const mockRemoveMember = mock(() => Promise.resolve());
+
+// We need to mock all exports that might be imported
+mock.module("@/features/memberships", () => ({
+  // Service functions
+  getMembershipByProfileAndCommunity: mockGetMembershipByProfileAndCommunity,
+  updateMembership: mockUpdateMembership,
+  removeMember: mockRemoveMember,
+  listCommunityMembersPaginated: mock(() => Promise.resolve({ items: [], pagination: {} })),
+  joinCommunity: mock(() => Promise.resolve(mockMembership)),
+  leaveCommunity: mock(() => Promise.resolve()),
+  transferOwnership: mock(() => Promise.resolve({})),
+  getMembership: mock(() => Promise.resolve(mockMembership)),
+  listCommunityMembers: mock(() => Promise.resolve([mockMembership])),
+  listActiveCommunityMembers: mock(() => Promise.resolve([mockMembership])),
+  getCommunityMemberCount: mock(() => Promise.resolve(1)),
+  isMember: mock(() => Promise.resolve(true)),
+  // Schemas
+  ListMembersQuerySchema: { parse: (data: unknown) => data },
+  UpdateMembershipSchema: { parse: (data: unknown) => data },
+  TransferOwnershipSchema: { parse: (data: unknown) => data },
+  MembershipResponseSchema: {},
+  ASSIGNABLE_ROLES: ["co_owner", "admin", "moderator", "member"],
+  COMMUNITY_ROLES: ["owner", "co_owner", "admin", "moderator", "member"],
+  MEMBERSHIP_STATUSES: ["active", "pending", "banned"],
+  ROLE_HIERARCHY: { owner: 5, co_owner: 4, admin: 3, moderator: 2, member: 1 },
+  // Permissions
+  canAssignRole: () => true,
+  canBanMembers: () => true,
+  canManageAdmins: () => true,
+  canManageModerators: () => true,
+  canManageRole: () => true,
+  hasMinimumRole: () => true,
+  // Errors
+  InsufficientPermissionsError,
+  MembershipError: class extends Error {},
+  AlreadyMemberError: class extends Error {},
+  BannedUserError: class extends Error {},
+  CannotModifyOwnerError: class extends Error {},
+  InvalidRoleAssignmentError: class extends Error {},
+  MembershipNotFoundError: class extends Error {},
+  NotMemberError: class extends Error {},
+  OwnerCannotLeaveError: class extends Error {},
+}));
+
+// Import routes after mocking
+const { PATCH, DELETE } = await import("./route");
+
+describe("PATCH /api/communities/[slug]/members/[profileId]", () => {
+  beforeEach(() => {
+    mockGetUser.mockClear();
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockUpdateMembership.mockClear();
+    mockUpdateMembership.mockResolvedValue({ ...mockMembership, role: "moderator" });
+  });
+
+  it("updates member role for admin user", async () => {
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/members/profile-456",
+      {
+        method: "PATCH",
+        body: JSON.stringify({ role: "moderator" }),
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    const response = await PATCH(request, {
+      params: Promise.resolve({ slug: "test-community", profileId: "profile-456" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.role).toBe("moderator");
+  });
+
+  it("returns 401 for unauthenticated user", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/members/profile-456",
+      {
+        method: "PATCH",
+        body: JSON.stringify({ role: "moderator" }),
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    const response = await PATCH(request, {
+      params: Promise.resolve({ slug: "test-community", profileId: "profile-456" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 for insufficient permissions", async () => {
+    mockUpdateMembership.mockRejectedValueOnce(
+      new InsufficientPermissionsError("update membership"),
+    );
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/members/profile-456",
+      {
+        method: "PATCH",
+        body: JSON.stringify({ role: "admin" }),
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    const response = await PATCH(request, {
+      params: Promise.resolve({ slug: "test-community", profileId: "profile-456" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.code).toBe("INSUFFICIENT_PERMISSIONS");
+  });
+});
+
+describe("DELETE /api/communities/[slug]/members/[profileId]", () => {
+  beforeEach(() => {
+    mockGetUser.mockClear();
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockRemoveMember.mockClear();
+    mockRemoveMember.mockResolvedValue(undefined);
+  });
+
+  it("removes member for admin user", async () => {
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/members/profile-456",
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ slug: "test-community", profileId: "profile-456" }),
+    });
+
+    expect(response.status).toBe(204);
+  });
+
+  it("returns 401 for unauthenticated user", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/members/profile-456",
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ slug: "test-community", profileId: "profile-456" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 for insufficient permissions", async () => {
+    mockRemoveMember.mockRejectedValueOnce(new InsufficientPermissionsError("remove member"));
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/members/profile-456",
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ slug: "test-community", profileId: "profile-456" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.code).toBe("INSUFFICIENT_PERMISSIONS");
+  });
+});

--- a/src/app/api/communities/[slug]/members/[profileId]/route.ts
+++ b/src/app/api/communities/[slug]/members/[profileId]/route.ts
@@ -1,0 +1,103 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { handleApiError, unauthorizedResponse } from "@/core/api/errors";
+import { getLogger } from "@/core/logging";
+import { createClient } from "@/core/supabase/server";
+import { getCommunityBySlug } from "@/features/communities";
+import {
+  getMembershipByProfileAndCommunity,
+  removeMember,
+  UpdateMembershipSchema,
+  updateMembership,
+} from "@/features/memberships";
+import { getProfileByUserId } from "@/features/profiles";
+
+const logger = getLogger("api.communities.members.profile");
+
+interface RouteParams {
+  params: Promise<{ slug: string; profileId: string }>;
+}
+
+/**
+ * PATCH /api/communities/[slug]/members/[profileId]
+ * Update a member's role or status.
+ */
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return unauthorizedResponse();
+    }
+
+    const { slug, profileId: targetProfileId } = await params;
+
+    const body = await request.json();
+    const input = UpdateMembershipSchema.parse(body);
+
+    logger.info({ slug, targetProfileId, userId: user.id }, "members.update_started");
+
+    const community = await getCommunityBySlug(slug);
+    const actorProfile = await getProfileByUserId(user.id);
+    const targetMembership = await getMembershipByProfileAndCommunity(
+      targetProfileId,
+      community.communityId,
+    );
+
+    const membership = await updateMembership(
+      targetMembership.membershipId,
+      input,
+      actorProfile.profileId,
+      community.communityId,
+    );
+
+    logger.info({ membershipId: membership.membershipId, slug }, "members.update_completed");
+
+    return NextResponse.json(membership);
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+
+/**
+ * DELETE /api/communities/[slug]/members/[profileId]
+ * Remove a member from the community.
+ */
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return unauthorizedResponse();
+    }
+
+    const { slug, profileId: targetProfileId } = await params;
+
+    logger.info({ slug, targetProfileId, userId: user.id }, "members.remove_started");
+
+    const community = await getCommunityBySlug(slug);
+    const actorProfile = await getProfileByUserId(user.id);
+    const targetMembership = await getMembershipByProfileAndCommunity(
+      targetProfileId,
+      community.communityId,
+    );
+
+    await removeMember(
+      targetMembership.membershipId,
+      actorProfile.profileId,
+      community.communityId,
+    );
+
+    logger.info({ slug, targetProfileId }, "members.remove_completed");
+
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/src/app/api/communities/[slug]/members/me/route.test.ts
+++ b/src/app/api/communities/[slug]/members/me/route.test.ts
@@ -118,9 +118,13 @@ mock.module("@/features/memberships", () => ({
   AlreadyMemberError: class extends Error {},
   BannedUserError: class extends Error {},
   CannotModifyOwnerError: class extends Error {},
+  DatabaseError: class extends Error {},
   InsufficientPermissionsError: class extends Error {},
   InvalidRoleAssignmentError: class extends Error {},
+  MembershipCreationFailedError: class extends Error {},
+  MembershipDeleteFailedError: class extends Error {},
   MembershipNotFoundError: class extends Error {},
+  OwnershipTransferFailedError: class extends Error {},
 }));
 
 // Import routes after mocking

--- a/src/app/api/communities/[slug]/members/me/route.test.ts
+++ b/src/app/api/communities/[slug]/members/me/route.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { NextRequest } from "next/server";
+
+// Mock user type
+type MockUser = { id: string; email: string } | null;
+const mockUser: MockUser = { id: "user-123", email: "test@example.com" };
+
+type Membership = {
+  membershipId: string;
+  communityId: string;
+  profileId: string;
+  role: "owner" | "co_owner" | "admin" | "moderator" | "member";
+  status: "active" | "pending" | "banned";
+  invitedByProfileId: string | null;
+  joinedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+const mockMembership: Membership = {
+  membershipId: "membership-123",
+  communityId: "community-123",
+  profileId: "profile-123",
+  role: "member",
+  status: "active",
+  invitedByProfileId: null,
+  joinedAt: new Date("2024-01-01"),
+  createdAt: new Date("2024-01-01"),
+  updatedAt: new Date("2024-01-01"),
+};
+
+// NotMemberError class for testing
+class NotMemberError extends Error {
+  readonly code = "NOT_MEMBER";
+  readonly statusCode = 404;
+  constructor(communityId: string) {
+    super(`Not a member of community: ${communityId}`);
+    this.name = "NotMemberError";
+  }
+}
+
+// OwnerCannotLeaveError class for testing
+class OwnerCannotLeaveError extends Error {
+  readonly code = "OWNER_CANNOT_LEAVE";
+  readonly statusCode = 403;
+  constructor() {
+    super("Owner cannot leave community. Transfer ownership first.");
+    this.name = "OwnerCannotLeaveError";
+  }
+}
+
+// Mock Supabase auth
+const mockGetUser = mock<() => Promise<{ data: { user: MockUser }; error: null }>>(() =>
+  Promise.resolve({ data: { user: mockUser }, error: null }),
+);
+mock.module("@/core/supabase/server", () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: mockGetUser },
+    }),
+}));
+
+// Mock communities service
+const mockGetCommunityBySlug = mock(() =>
+  Promise.resolve({ communityId: "community-123", visibility: "public" }),
+);
+mock.module("@/features/communities", () => ({
+  getCommunityBySlug: mockGetCommunityBySlug,
+  CommunityError: class extends Error {},
+}));
+
+// Mock profiles service
+const mockGetProfileByUserId = mock(() => Promise.resolve({ profileId: "profile-123" }));
+mock.module("@/features/profiles", () => ({
+  getProfileByUserId: mockGetProfileByUserId,
+  ProfileError: class extends Error {},
+}));
+
+// Mock memberships service
+const mockGetMembershipByProfileAndCommunity = mock(() => Promise.resolve(mockMembership));
+const mockLeaveCommunity = mock(() => Promise.resolve());
+
+// We need to mock all exports that might be imported
+mock.module("@/features/memberships", () => ({
+  // Service functions
+  getMembershipByProfileAndCommunity: mockGetMembershipByProfileAndCommunity,
+  leaveCommunity: mockLeaveCommunity,
+  listCommunityMembersPaginated: mock(() => Promise.resolve({ items: [], pagination: {} })),
+  joinCommunity: mock(() => Promise.resolve(mockMembership)),
+  updateMembership: mock(() => Promise.resolve(mockMembership)),
+  removeMember: mock(() => Promise.resolve()),
+  transferOwnership: mock(() => Promise.resolve({})),
+  getMembership: mock(() => Promise.resolve(mockMembership)),
+  listCommunityMembers: mock(() => Promise.resolve([mockMembership])),
+  listActiveCommunityMembers: mock(() => Promise.resolve([mockMembership])),
+  getCommunityMemberCount: mock(() => Promise.resolve(1)),
+  isMember: mock(() => Promise.resolve(true)),
+  // Schemas
+  ListMembersQuerySchema: { parse: (data: unknown) => data },
+  UpdateMembershipSchema: { parse: (data: unknown) => data },
+  TransferOwnershipSchema: { parse: (data: unknown) => data },
+  MembershipResponseSchema: {},
+  ASSIGNABLE_ROLES: ["co_owner", "admin", "moderator", "member"],
+  COMMUNITY_ROLES: ["owner", "co_owner", "admin", "moderator", "member"],
+  MEMBERSHIP_STATUSES: ["active", "pending", "banned"],
+  ROLE_HIERARCHY: { owner: 5, co_owner: 4, admin: 3, moderator: 2, member: 1 },
+  // Permissions
+  canAssignRole: () => true,
+  canBanMembers: () => true,
+  canManageAdmins: () => true,
+  canManageModerators: () => true,
+  canManageRole: () => true,
+  hasMinimumRole: () => true,
+  // Errors
+  NotMemberError,
+  OwnerCannotLeaveError,
+  MembershipError: class extends Error {},
+  AlreadyMemberError: class extends Error {},
+  BannedUserError: class extends Error {},
+  CannotModifyOwnerError: class extends Error {},
+  InsufficientPermissionsError: class extends Error {},
+  InvalidRoleAssignmentError: class extends Error {},
+  MembershipNotFoundError: class extends Error {},
+}));
+
+// Import routes after mocking
+const { GET, DELETE } = await import("./route");
+
+describe("GET /api/communities/[slug]/members/me", () => {
+  beforeEach(() => {
+    mockGetUser.mockClear();
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockGetMembershipByProfileAndCommunity.mockClear();
+    mockGetMembershipByProfileAndCommunity.mockResolvedValue(mockMembership);
+  });
+
+  it("returns own membership for authenticated user", async () => {
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/members/me",
+    );
+    const response = await GET(request, { params: Promise.resolve({ slug: "test-community" }) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.membershipId).toBe("membership-123");
+    expect(data.role).toBe("member");
+  });
+
+  it("returns 401 for unauthenticated user", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/members/me",
+    );
+    const response = await GET(request, { params: Promise.resolve({ slug: "test-community" }) });
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 404 when not a member", async () => {
+    mockGetMembershipByProfileAndCommunity.mockRejectedValueOnce(
+      new NotMemberError("community-123"),
+    );
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/members/me",
+    );
+    const response = await GET(request, { params: Promise.resolve({ slug: "test-community" }) });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.code).toBe("NOT_MEMBER");
+  });
+});
+
+describe("DELETE /api/communities/[slug]/members/me", () => {
+  beforeEach(() => {
+    mockGetUser.mockClear();
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockLeaveCommunity.mockClear();
+    mockLeaveCommunity.mockResolvedValue(undefined);
+  });
+
+  it("leaves community for authenticated user", async () => {
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/members/me",
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ slug: "test-community" }),
+    });
+
+    expect(response.status).toBe(204);
+  });
+
+  it("returns 401 for unauthenticated user", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/members/me",
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ slug: "test-community" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 when owner tries to leave", async () => {
+    mockLeaveCommunity.mockRejectedValueOnce(new OwnerCannotLeaveError());
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/members/me",
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ slug: "test-community" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.code).toBe("OWNER_CANNOT_LEAVE");
+  });
+});

--- a/src/app/api/communities/[slug]/members/me/route.ts
+++ b/src/app/api/communities/[slug]/members/me/route.ts
@@ -1,0 +1,79 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { handleApiError, unauthorizedResponse } from "@/core/api/errors";
+import { getLogger } from "@/core/logging";
+import { createClient } from "@/core/supabase/server";
+import { getCommunityBySlug } from "@/features/communities";
+import { getMembershipByProfileAndCommunity, leaveCommunity } from "@/features/memberships";
+import { getProfileByUserId } from "@/features/profiles";
+
+const logger = getLogger("api.communities.members.me");
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+/**
+ * GET /api/communities/[slug]/members/me
+ * Get current user's membership in community.
+ */
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return unauthorizedResponse();
+    }
+
+    const { slug } = await params;
+
+    logger.info({ slug, userId: user.id }, "members.me.get_started");
+
+    const community = await getCommunityBySlug(slug);
+    const profile = await getProfileByUserId(user.id);
+    const membership = await getMembershipByProfileAndCommunity(
+      profile.profileId,
+      community.communityId,
+    );
+
+    logger.info({ membershipId: membership.membershipId, slug }, "members.me.get_completed");
+
+    return NextResponse.json(membership);
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+
+/**
+ * DELETE /api/communities/[slug]/members/me
+ * Leave a community.
+ */
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return unauthorizedResponse();
+    }
+
+    const { slug } = await params;
+
+    logger.info({ slug, userId: user.id }, "members.me.leave_started");
+
+    const community = await getCommunityBySlug(slug);
+    const profile = await getProfileByUserId(user.id);
+    await leaveCommunity(profile.profileId, community.communityId);
+
+    logger.info({ slug, userId: user.id }, "members.me.leave_completed");
+
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/src/app/api/communities/[slug]/members/route.test.ts
+++ b/src/app/api/communities/[slug]/members/route.test.ts
@@ -119,11 +119,15 @@ mock.module("@/features/memberships", () => ({
   MembershipError: class extends Error {},
   BannedUserError: class extends Error {},
   CannotModifyOwnerError: class extends Error {},
+  DatabaseError: class extends Error {},
   InsufficientPermissionsError: class extends Error {},
   InvalidRoleAssignmentError: class extends Error {},
+  MembershipCreationFailedError: class extends Error {},
+  MembershipDeleteFailedError: class extends Error {},
   MembershipNotFoundError: class extends Error {},
   NotMemberError: class extends Error {},
   OwnerCannotLeaveError: class extends Error {},
+  OwnershipTransferFailedError: class extends Error {},
 }));
 
 // Import routes after mocking

--- a/src/app/api/communities/[slug]/members/route.test.ts
+++ b/src/app/api/communities/[slug]/members/route.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { NextRequest } from "next/server";
+
+import type { PaginatedResponse } from "@/shared/schemas/pagination";
+
+// Mock user type
+type MockUser = { id: string; email: string } | null;
+const mockUser: MockUser = { id: "user-123", email: "test@example.com" };
+
+type Membership = {
+  membershipId: string;
+  communityId: string;
+  profileId: string;
+  role: "owner" | "co_owner" | "admin" | "moderator" | "member";
+  status: "active" | "pending" | "banned";
+  invitedByProfileId: string | null;
+  joinedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+const mockMembership: Membership = {
+  membershipId: "membership-123",
+  communityId: "community-123",
+  profileId: "profile-123",
+  role: "member",
+  status: "active",
+  invitedByProfileId: null,
+  joinedAt: new Date("2024-01-01"),
+  createdAt: new Date("2024-01-01"),
+  updatedAt: new Date("2024-01-01"),
+};
+
+const mockPaginatedResponse: PaginatedResponse<Membership> = {
+  items: [mockMembership],
+  pagination: { page: 1, pageSize: 20, total: 1, totalPages: 1 },
+};
+
+// AlreadyMemberError class for testing
+class AlreadyMemberError extends Error {
+  readonly code = "ALREADY_MEMBER";
+  readonly statusCode = 409;
+  constructor(communityId: string) {
+    super(`Already a member of community: ${communityId}`);
+    this.name = "AlreadyMemberError";
+  }
+}
+
+// Mock Supabase auth
+const mockGetUser = mock<() => Promise<{ data: { user: MockUser }; error: null }>>(() =>
+  Promise.resolve({ data: { user: mockUser }, error: null }),
+);
+mock.module("@/core/supabase/server", () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: mockGetUser },
+    }),
+}));
+
+// Mock communities service
+const mockGetCommunityBySlug = mock(() =>
+  Promise.resolve({ communityId: "community-123", visibility: "public" }),
+);
+mock.module("@/features/communities", () => ({
+  getCommunityBySlug: mockGetCommunityBySlug,
+  CommunityError: class extends Error {},
+}));
+
+// Mock profiles service
+const mockGetProfileByUserId = mock(() => Promise.resolve({ profileId: "profile-123" }));
+mock.module("@/features/profiles", () => ({
+  getProfileByUserId: mockGetProfileByUserId,
+  ProfileError: class extends Error {},
+}));
+
+// Mock memberships service
+const mockListCommunityMembersPaginated = mock(() => Promise.resolve(mockPaginatedResponse));
+const mockJoinCommunity = mock(() => Promise.resolve(mockMembership));
+
+// We need to mock all exports that might be imported
+mock.module("@/features/memberships", () => ({
+  // Service functions
+  listCommunityMembersPaginated: mockListCommunityMembersPaginated,
+  joinCommunity: mockJoinCommunity,
+  getMembershipByProfileAndCommunity: mock(() => Promise.resolve(mockMembership)),
+  leaveCommunity: mock(() => Promise.resolve()),
+  updateMembership: mock(() => Promise.resolve(mockMembership)),
+  removeMember: mock(() => Promise.resolve()),
+  transferOwnership: mock(() => Promise.resolve({})),
+  getMembership: mock(() => Promise.resolve(mockMembership)),
+  listCommunityMembers: mock(() => Promise.resolve([mockMembership])),
+  listActiveCommunityMembers: mock(() => Promise.resolve([mockMembership])),
+  getCommunityMemberCount: mock(() => Promise.resolve(1)),
+  isMember: mock(() => Promise.resolve(true)),
+  // Schemas
+  ListMembersQuerySchema: {
+    parse: (data: unknown) => ({
+      page: 1,
+      pageSize: 20,
+      ...(data as object),
+    }),
+  },
+  UpdateMembershipSchema: { parse: (data: unknown) => data },
+  TransferOwnershipSchema: { parse: (data: unknown) => data },
+  MembershipResponseSchema: {},
+  ASSIGNABLE_ROLES: ["co_owner", "admin", "moderator", "member"],
+  COMMUNITY_ROLES: ["owner", "co_owner", "admin", "moderator", "member"],
+  MEMBERSHIP_STATUSES: ["active", "pending", "banned"],
+  ROLE_HIERARCHY: { owner: 5, co_owner: 4, admin: 3, moderator: 2, member: 1 },
+  // Permissions
+  canAssignRole: () => true,
+  canBanMembers: () => true,
+  canManageAdmins: () => true,
+  canManageModerators: () => true,
+  canManageRole: () => true,
+  hasMinimumRole: () => true,
+  // Errors
+  AlreadyMemberError,
+  MembershipError: class extends Error {},
+  BannedUserError: class extends Error {},
+  CannotModifyOwnerError: class extends Error {},
+  InsufficientPermissionsError: class extends Error {},
+  InvalidRoleAssignmentError: class extends Error {},
+  MembershipNotFoundError: class extends Error {},
+  NotMemberError: class extends Error {},
+  OwnerCannotLeaveError: class extends Error {},
+}));
+
+// Import routes after mocking
+const { GET, POST } = await import("./route");
+
+describe("GET /api/communities/[slug]/members", () => {
+  beforeEach(() => {
+    mockGetCommunityBySlug.mockClear();
+    mockListCommunityMembersPaginated.mockClear();
+  });
+
+  it("returns paginated members list", async () => {
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/members?page=1&pageSize=20",
+    );
+    const response = await GET(request, { params: Promise.resolve({ slug: "test-community" }) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.items).toHaveLength(1);
+    expect(data.pagination.page).toBe(1);
+  });
+
+  it("calls service with correct community ID", async () => {
+    const request = new NextRequest("http://localhost:3000/api/communities/test-community/members");
+    await GET(request, { params: Promise.resolve({ slug: "test-community" }) });
+
+    expect(mockGetCommunityBySlug).toHaveBeenCalledWith("test-community");
+    expect(mockListCommunityMembersPaginated).toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/communities/[slug]/members", () => {
+  beforeEach(() => {
+    mockGetUser.mockClear();
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockJoinCommunity.mockClear();
+    mockJoinCommunity.mockResolvedValue(mockMembership);
+  });
+
+  it("joins community for authenticated user", async () => {
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/members",
+      { method: "POST" },
+    );
+    const response = await POST(request, { params: Promise.resolve({ slug: "test-community" }) });
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.membershipId).toBe("membership-123");
+  });
+
+  it("returns 401 for unauthenticated user", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/members",
+      { method: "POST" },
+    );
+    const response = await POST(request, { params: Promise.resolve({ slug: "test-community" }) });
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 409 when already a member", async () => {
+    mockJoinCommunity.mockRejectedValueOnce(new AlreadyMemberError("community-123"));
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/members",
+      { method: "POST" },
+    );
+    const response = await POST(request, { params: Promise.resolve({ slug: "test-community" }) });
+    const data = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(data.code).toBe("ALREADY_MEMBER");
+  });
+});

--- a/src/app/api/communities/[slug]/members/route.ts
+++ b/src/app/api/communities/[slug]/members/route.ts
@@ -4,7 +4,11 @@ import { handleApiError, unauthorizedResponse } from "@/core/api/errors";
 import { getLogger } from "@/core/logging";
 import { createClient } from "@/core/supabase/server";
 import { getCommunityBySlug } from "@/features/communities";
-import { joinCommunity, listCommunityMembers } from "@/features/memberships";
+import {
+  joinCommunity,
+  ListMembersQuerySchema,
+  listCommunityMembersPaginated,
+} from "@/features/memberships";
 import { getProfileByUserId } from "@/features/profiles";
 
 const logger = getLogger("api.communities.members");
@@ -15,20 +19,44 @@ interface RouteParams {
 
 /**
  * GET /api/communities/[slug]/members
- * List all members of a community.
+ * List all members of a community with pagination.
  */
-export async function GET(_request: NextRequest, { params }: RouteParams) {
+export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
     const { slug } = await params;
+    const { searchParams } = new URL(request.url);
 
-    logger.info({ slug }, "members.list_started");
+    // Parse pagination and filter params
+    const queryParams = ListMembersQuerySchema.parse({
+      page: searchParams.get("page") ? Number(searchParams.get("page")) : undefined,
+      pageSize: searchParams.get("pageSize") ? Number(searchParams.get("pageSize")) : undefined,
+      status: searchParams.get("status") ?? undefined,
+      role: searchParams.get("role") ?? undefined,
+    });
+
+    logger.info({ slug, ...queryParams }, "members.list_started");
 
     const community = await getCommunityBySlug(slug);
-    const members = await listCommunityMembers(community.communityId);
 
-    logger.info({ slug, count: members.length }, "members.list_completed");
+    // Build filters object for exactOptionalPropertyTypes
+    type CommunityRole = "owner" | "co_owner" | "admin" | "moderator" | "member";
+    const filters: { status?: "active" | "pending" | "banned"; role?: CommunityRole } = {};
+    if (queryParams.status !== undefined) {
+      filters.status = queryParams.status;
+    }
+    if (queryParams.role !== undefined) {
+      filters.role = queryParams.role;
+    }
 
-    return NextResponse.json(members);
+    const result = await listCommunityMembersPaginated(
+      community.communityId,
+      { page: queryParams.page, pageSize: queryParams.pageSize },
+      filters,
+    );
+
+    logger.info({ slug, count: result.items.length }, "members.list_completed");
+
+    return NextResponse.json(result);
   } catch (error) {
     return handleApiError(error);
   }

--- a/src/app/api/communities/[slug]/members/route.ts
+++ b/src/app/api/communities/[slug]/members/route.ts
@@ -1,0 +1,70 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { handleApiError, unauthorizedResponse } from "@/core/api/errors";
+import { getLogger } from "@/core/logging";
+import { createClient } from "@/core/supabase/server";
+import { getCommunityBySlug } from "@/features/communities";
+import { joinCommunity, listCommunityMembers } from "@/features/memberships";
+import { getProfileByUserId } from "@/features/profiles";
+
+const logger = getLogger("api.communities.members");
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+/**
+ * GET /api/communities/[slug]/members
+ * List all members of a community.
+ */
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const { slug } = await params;
+
+    logger.info({ slug }, "members.list_started");
+
+    const community = await getCommunityBySlug(slug);
+    const members = await listCommunityMembers(community.communityId);
+
+    logger.info({ slug, count: members.length }, "members.list_completed");
+
+    return NextResponse.json(members);
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+
+/**
+ * POST /api/communities/[slug]/members
+ * Join a community.
+ */
+export async function POST(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return unauthorizedResponse();
+    }
+
+    const { slug } = await params;
+
+    logger.info({ slug, userId: user.id }, "members.join_started");
+
+    const community = await getCommunityBySlug(slug);
+    const profile = await getProfileByUserId(user.id);
+    const membership = await joinCommunity(
+      profile.profileId,
+      community.communityId,
+      community.visibility,
+    );
+
+    logger.info({ membershipId: membership.membershipId, slug }, "members.join_completed");
+
+    return NextResponse.json(membership, { status: 201 });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/src/app/api/communities/[slug]/transfer-ownership/route.test.ts
+++ b/src/app/api/communities/[slug]/transfer-ownership/route.test.ts
@@ -134,9 +134,13 @@ mock.module("@/features/memberships", () => ({
   AlreadyMemberError: class extends Error {},
   BannedUserError: class extends Error {},
   CannotModifyOwnerError: class extends Error {},
+  DatabaseError: class extends Error {},
   InvalidRoleAssignmentError: class extends Error {},
+  MembershipCreationFailedError: class extends Error {},
+  MembershipDeleteFailedError: class extends Error {},
   MembershipNotFoundError: class extends Error {},
   OwnerCannotLeaveError: class extends Error {},
+  OwnershipTransferFailedError: class extends Error {},
 }));
 
 // Import routes after mocking

--- a/src/app/api/communities/[slug]/transfer-ownership/route.test.ts
+++ b/src/app/api/communities/[slug]/transfer-ownership/route.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { NextRequest } from "next/server";
+
+// Mock user type
+type MockUser = { id: string; email: string } | null;
+const mockUser: MockUser = { id: "user-123", email: "test@example.com" };
+
+type Membership = {
+  membershipId: string;
+  communityId: string;
+  profileId: string;
+  role: "owner" | "co_owner" | "admin" | "moderator" | "member";
+  status: "active" | "pending" | "banned";
+  invitedByProfileId: string | null;
+  joinedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+const mockOldOwnerMembership: Membership = {
+  membershipId: "membership-123",
+  communityId: "community-123",
+  profileId: "profile-123",
+  role: "co_owner",
+  status: "active",
+  invitedByProfileId: null,
+  joinedAt: new Date("2024-01-01"),
+  createdAt: new Date("2024-01-01"),
+  updatedAt: new Date("2024-01-01"),
+};
+
+const mockNewOwnerMembership: Membership = {
+  membershipId: "membership-456",
+  communityId: "community-123",
+  profileId: "profile-456",
+  role: "owner",
+  status: "active",
+  invitedByProfileId: null,
+  joinedAt: new Date("2024-01-01"),
+  createdAt: new Date("2024-01-01"),
+  updatedAt: new Date("2024-01-01"),
+};
+
+// InsufficientPermissionsError class for testing
+class InsufficientPermissionsError extends Error {
+  readonly code = "INSUFFICIENT_PERMISSIONS";
+  readonly statusCode = 403;
+  constructor(action: string) {
+    super(`Insufficient permissions to: ${action}`);
+    this.name = "InsufficientPermissionsError";
+  }
+}
+
+// NotMemberError class for testing
+class NotMemberError extends Error {
+  readonly code = "NOT_MEMBER";
+  readonly statusCode = 404;
+  constructor(communityId: string) {
+    super(`Not a member of community: ${communityId}`);
+    this.name = "NotMemberError";
+  }
+}
+
+// Mock Supabase auth
+const mockGetUser = mock<() => Promise<{ data: { user: MockUser }; error: null }>>(() =>
+  Promise.resolve({ data: { user: mockUser }, error: null }),
+);
+mock.module("@/core/supabase/server", () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: mockGetUser },
+    }),
+}));
+
+// Mock communities service
+const mockGetCommunityBySlug = mock(() =>
+  Promise.resolve({ communityId: "community-123", visibility: "public" }),
+);
+mock.module("@/features/communities", () => ({
+  getCommunityBySlug: mockGetCommunityBySlug,
+  CommunityError: class extends Error {},
+}));
+
+// Mock profiles service
+const mockGetProfileByUserId = mock(() => Promise.resolve({ profileId: "profile-123" }));
+mock.module("@/features/profiles", () => ({
+  getProfileByUserId: mockGetProfileByUserId,
+  ProfileError: class extends Error {},
+}));
+
+// Mock memberships service
+const mockTransferOwnership = mock(() =>
+  Promise.resolve({
+    oldOwnerMembership: mockOldOwnerMembership,
+    newOwnerMembership: mockNewOwnerMembership,
+  }),
+);
+
+// We need to mock all exports that might be imported
+mock.module("@/features/memberships", () => ({
+  // Service functions
+  transferOwnership: mockTransferOwnership,
+  getMembershipByProfileAndCommunity: mock(() => Promise.resolve(mockNewOwnerMembership)),
+  listCommunityMembersPaginated: mock(() => Promise.resolve({ items: [], pagination: {} })),
+  joinCommunity: mock(() => Promise.resolve(mockNewOwnerMembership)),
+  leaveCommunity: mock(() => Promise.resolve()),
+  updateMembership: mock(() => Promise.resolve(mockNewOwnerMembership)),
+  removeMember: mock(() => Promise.resolve()),
+  getMembership: mock(() => Promise.resolve(mockNewOwnerMembership)),
+  listCommunityMembers: mock(() => Promise.resolve([mockNewOwnerMembership])),
+  listActiveCommunityMembers: mock(() => Promise.resolve([mockNewOwnerMembership])),
+  getCommunityMemberCount: mock(() => Promise.resolve(1)),
+  isMember: mock(() => Promise.resolve(true)),
+  // Schemas
+  ListMembersQuerySchema: { parse: (data: unknown) => data },
+  UpdateMembershipSchema: { parse: (data: unknown) => data },
+  TransferOwnershipSchema: { parse: (data: unknown) => data },
+  MembershipResponseSchema: {},
+  ASSIGNABLE_ROLES: ["co_owner", "admin", "moderator", "member"],
+  COMMUNITY_ROLES: ["owner", "co_owner", "admin", "moderator", "member"],
+  MEMBERSHIP_STATUSES: ["active", "pending", "banned"],
+  ROLE_HIERARCHY: { owner: 5, co_owner: 4, admin: 3, moderator: 2, member: 1 },
+  // Permissions
+  canAssignRole: () => true,
+  canBanMembers: () => true,
+  canManageAdmins: () => true,
+  canManageModerators: () => true,
+  canManageRole: () => true,
+  hasMinimumRole: () => true,
+  // Errors
+  InsufficientPermissionsError,
+  NotMemberError,
+  MembershipError: class extends Error {},
+  AlreadyMemberError: class extends Error {},
+  BannedUserError: class extends Error {},
+  CannotModifyOwnerError: class extends Error {},
+  InvalidRoleAssignmentError: class extends Error {},
+  MembershipNotFoundError: class extends Error {},
+  OwnerCannotLeaveError: class extends Error {},
+}));
+
+// Import routes after mocking
+const { POST } = await import("./route");
+
+describe("POST /api/communities/[slug]/transfer-ownership", () => {
+  beforeEach(() => {
+    mockGetUser.mockClear();
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockTransferOwnership.mockClear();
+    mockTransferOwnership.mockResolvedValue({
+      oldOwnerMembership: mockOldOwnerMembership,
+      newOwnerMembership: mockNewOwnerMembership,
+    });
+  });
+
+  it("transfers ownership for owner", async () => {
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/transfer-ownership",
+      {
+        method: "POST",
+        body: JSON.stringify({ newOwnerProfileId: "profile-456" }),
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    const response = await POST(request, {
+      params: Promise.resolve({ slug: "test-community" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.oldOwnerMembership.role).toBe("co_owner");
+    expect(data.newOwnerMembership.role).toBe("owner");
+  });
+
+  it("returns 401 for unauthenticated user", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/transfer-ownership",
+      {
+        method: "POST",
+        body: JSON.stringify({ newOwnerProfileId: "profile-456" }),
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    const response = await POST(request, {
+      params: Promise.resolve({ slug: "test-community" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 when non-owner tries to transfer", async () => {
+    mockTransferOwnership.mockRejectedValueOnce(
+      new InsufficientPermissionsError("transfer ownership"),
+    );
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/transfer-ownership",
+      {
+        method: "POST",
+        body: JSON.stringify({ newOwnerProfileId: "profile-456" }),
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    const response = await POST(request, {
+      params: Promise.resolve({ slug: "test-community" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.code).toBe("INSUFFICIENT_PERMISSIONS");
+  });
+
+  it("returns 404 when new owner is not a member", async () => {
+    mockTransferOwnership.mockRejectedValueOnce(new NotMemberError("community-123"));
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/communities/test-community/transfer-ownership",
+      {
+        method: "POST",
+        body: JSON.stringify({ newOwnerProfileId: "profile-999" }),
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    const response = await POST(request, {
+      params: Promise.resolve({ slug: "test-community" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.code).toBe("NOT_MEMBER");
+  });
+});

--- a/src/app/api/communities/[slug]/transfer-ownership/route.ts
+++ b/src/app/api/communities/[slug]/transfer-ownership/route.ts
@@ -1,0 +1,52 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { handleApiError, unauthorizedResponse } from "@/core/api/errors";
+import { getLogger } from "@/core/logging";
+import { createClient } from "@/core/supabase/server";
+import { getCommunityBySlug } from "@/features/communities";
+import { TransferOwnershipSchema, transferOwnership } from "@/features/memberships";
+import { getProfileByUserId } from "@/features/profiles";
+
+const logger = getLogger("api.communities.transfer-ownership");
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+/**
+ * POST /api/communities/[slug]/transfer-ownership
+ * Transfer community ownership to another active member.
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return unauthorizedResponse();
+    }
+
+    const { slug } = await params;
+    const body = await request.json();
+    const { newOwnerProfileId } = TransferOwnershipSchema.parse(body);
+
+    logger.info({ slug, userId: user.id, newOwnerProfileId }, "transfer-ownership_started");
+
+    const community = await getCommunityBySlug(slug);
+    const currentOwnerProfile = await getProfileByUserId(user.id);
+
+    const result = await transferOwnership(
+      community.communityId,
+      currentOwnerProfile.profileId,
+      newOwnerProfileId,
+    );
+
+    logger.info({ slug, newOwnerProfileId }, "transfer-ownership_completed");
+
+    return NextResponse.json(result);
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/src/core/api/errors.ts
+++ b/src/core/api/errors.ts
@@ -3,6 +3,7 @@ import { ZodError } from "zod/v4";
 
 import { getLogger } from "@/core/logging";
 import { CommunityError } from "@/features/communities";
+import { MembershipError } from "@/features/memberships";
 import { ProfileError } from "@/features/profiles";
 import { StorageError } from "@/features/storage";
 import { createErrorResponse, type ErrorResponse } from "@/shared/schemas/errors";
@@ -99,4 +100,4 @@ export function unauthorizedResponse(): NextResponse<ErrorResponse> {
 }
 
 // Re-export errors for type checking in other modules
-export { CommunityError, ProfileError, StorageError };
+export { CommunityError, MembershipError, ProfileError, StorageError };

--- a/src/core/database/schema.ts
+++ b/src/core/database/schema.ts
@@ -75,6 +75,22 @@ export const communityVisibilityEnum = pgEnum("community_visibility", [
 ]);
 
 /**
+ * Community role enum for membership role hierarchy.
+ */
+export const communityRoleEnum = pgEnum("community_role", [
+  "owner",
+  "co_owner",
+  "admin",
+  "moderator",
+  "member",
+]);
+
+/**
+ * Membership status enum for membership states.
+ */
+export const membershipStatusEnum = pgEnum("membership_status", ["active", "pending", "banned"]);
+
+/**
  * Communities table - groups of users organized around shared interests.
  */
 export const communities = pgTable("communities", {
@@ -90,5 +106,23 @@ export const communities = pgTable("communities", {
   bannerUrl: text("banner_url"),
   visibility: communityVisibilityEnum("visibility").notNull().default("public"),
   settings: jsonb("settings").$type<Record<string, unknown>>().default({}),
+  ...timestamps,
+});
+
+/**
+ * Memberships table - tracks user-community relationships with roles.
+ */
+export const memberships = pgTable("memberships", {
+  membershipId: uuid("membership_id").primaryKey().defaultRandom(),
+  communityId: uuid("community_id")
+    .notNull()
+    .references(() => communities.communityId, { onDelete: "cascade" }),
+  profileId: uuid("profile_id")
+    .notNull()
+    .references(() => profiles.profileId, { onDelete: "cascade" }),
+  role: communityRoleEnum("role").notNull().default("member"),
+  status: membershipStatusEnum("status").notNull().default("active"),
+  invitedByProfileId: uuid("invited_by_profile_id").references(() => profiles.profileId),
+  joinedAt: timestamp("joined_at").defaultNow().notNull(),
   ...timestamps,
 });

--- a/src/features/memberships/errors.ts
+++ b/src/features/memberships/errors.ts
@@ -10,7 +10,8 @@ export type MembershipErrorCode =
   | "INSUFFICIENT_PERMISSIONS"
   | "CANNOT_MODIFY_OWNER"
   | "OWNER_CANNOT_LEAVE"
-  | "INVALID_ROLE_ASSIGNMENT";
+  | "INVALID_ROLE_ASSIGNMENT"
+  | "USER_BANNED";
 
 /**
  * Base error for membership-related errors.
@@ -66,5 +67,11 @@ export class OwnerCannotLeaveError extends MembershipError {
 export class InvalidRoleAssignmentError extends MembershipError {
   constructor(role: CommunityRole) {
     super(`Cannot assign role: ${role}`, "INVALID_ROLE_ASSIGNMENT", 403);
+  }
+}
+
+export class BannedUserError extends MembershipError {
+  constructor(communityId: string) {
+    super(`User is banned from community: ${communityId}`, "USER_BANNED", 403);
   }
 }

--- a/src/features/memberships/errors.ts
+++ b/src/features/memberships/errors.ts
@@ -11,7 +11,11 @@ export type MembershipErrorCode =
   | "CANNOT_MODIFY_OWNER"
   | "OWNER_CANNOT_LEAVE"
   | "INVALID_ROLE_ASSIGNMENT"
-  | "USER_BANNED";
+  | "USER_BANNED"
+  | "MEMBERSHIP_CREATION_FAILED"
+  | "OWNERSHIP_TRANSFER_FAILED"
+  | "MEMBERSHIP_DELETE_FAILED"
+  | "DATABASE_ERROR";
 
 /**
  * Base error for membership-related errors.
@@ -73,5 +77,37 @@ export class InvalidRoleAssignmentError extends MembershipError {
 export class BannedUserError extends MembershipError {
   constructor(communityId: string) {
     super(`User is banned from community: ${communityId}`, "USER_BANNED", 403);
+  }
+}
+
+export class MembershipCreationFailedError extends MembershipError {
+  constructor(communityId: string) {
+    super(
+      `Failed to create membership for community: ${communityId}`,
+      "MEMBERSHIP_CREATION_FAILED",
+      500,
+    );
+  }
+}
+
+export class OwnershipTransferFailedError extends MembershipError {
+  constructor(communityId: string) {
+    super(
+      `Failed to transfer ownership for community: ${communityId}`,
+      "OWNERSHIP_TRANSFER_FAILED",
+      500,
+    );
+  }
+}
+
+export class MembershipDeleteFailedError extends MembershipError {
+  constructor(membershipId: string) {
+    super(`Failed to delete membership: ${membershipId}`, "MEMBERSHIP_DELETE_FAILED", 500);
+  }
+}
+
+export class DatabaseError extends MembershipError {
+  constructor(operation: string) {
+    super(`Database error during: ${operation}`, "DATABASE_ERROR", 500);
   }
 }

--- a/src/features/memberships/errors.ts
+++ b/src/features/memberships/errors.ts
@@ -1,5 +1,7 @@
 import type { HttpStatusCode } from "@/core/api/errors";
 
+import type { CommunityRole } from "./schemas";
+
 /** Known error codes for membership operations. */
 export type MembershipErrorCode =
   | "MEMBERSHIP_NOT_FOUND"
@@ -62,7 +64,7 @@ export class OwnerCannotLeaveError extends MembershipError {
 }
 
 export class InvalidRoleAssignmentError extends MembershipError {
-  constructor(role: string) {
+  constructor(role: CommunityRole) {
     super(`Cannot assign role: ${role}`, "INVALID_ROLE_ASSIGNMENT", 403);
   }
 }

--- a/src/features/memberships/errors.ts
+++ b/src/features/memberships/errors.ts
@@ -1,0 +1,68 @@
+import type { HttpStatusCode } from "@/core/api/errors";
+
+/** Known error codes for membership operations. */
+export type MembershipErrorCode =
+  | "MEMBERSHIP_NOT_FOUND"
+  | "ALREADY_MEMBER"
+  | "NOT_MEMBER"
+  | "INSUFFICIENT_PERMISSIONS"
+  | "CANNOT_MODIFY_OWNER"
+  | "OWNER_CANNOT_LEAVE"
+  | "INVALID_ROLE_ASSIGNMENT";
+
+/**
+ * Base error for membership-related errors.
+ */
+export class MembershipError extends Error {
+  readonly code: MembershipErrorCode;
+  readonly statusCode: HttpStatusCode;
+
+  constructor(message: string, code: MembershipErrorCode, statusCode: HttpStatusCode) {
+    super(message);
+    this.name = this.constructor.name;
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+export class MembershipNotFoundError extends MembershipError {
+  constructor(identifier: string) {
+    super(`Membership not found: ${identifier}`, "MEMBERSHIP_NOT_FOUND", 404);
+  }
+}
+
+export class AlreadyMemberError extends MembershipError {
+  constructor(communityId: string) {
+    super(`Already a member of community: ${communityId}`, "ALREADY_MEMBER", 409);
+  }
+}
+
+export class NotMemberError extends MembershipError {
+  constructor(communityId: string) {
+    super(`Not a member of community: ${communityId}`, "NOT_MEMBER", 404);
+  }
+}
+
+export class InsufficientPermissionsError extends MembershipError {
+  constructor(action: string) {
+    super(`Insufficient permissions to: ${action}`, "INSUFFICIENT_PERMISSIONS", 403);
+  }
+}
+
+export class CannotModifyOwnerError extends MembershipError {
+  constructor() {
+    super("Cannot modify the community owner", "CANNOT_MODIFY_OWNER", 403);
+  }
+}
+
+export class OwnerCannotLeaveError extends MembershipError {
+  constructor() {
+    super("Owner cannot leave community. Transfer ownership first.", "OWNER_CANNOT_LEAVE", 403);
+  }
+}
+
+export class InvalidRoleAssignmentError extends MembershipError {
+  constructor(role: string) {
+    super(`Cannot assign role: ${role}`, "INVALID_ROLE_ASSIGNMENT", 403);
+  }
+}

--- a/src/features/memberships/index.ts
+++ b/src/features/memberships/index.ts
@@ -2,6 +2,7 @@
 export type { MembershipErrorCode } from "./errors";
 export {
   AlreadyMemberError,
+  BannedUserError,
   CannotModifyOwnerError,
   InsufficientPermissionsError,
   InvalidRoleAssignmentError,
@@ -25,6 +26,7 @@ export {
 export type {
   AssignableRole,
   CommunityRole,
+  ListMembersQuery,
   MembershipResponse,
   MembershipStatus,
   TransferOwnershipInput,
@@ -33,6 +35,7 @@ export type {
 export {
   ASSIGNABLE_ROLES,
   COMMUNITY_ROLES,
+  ListMembersQuerySchema,
   MEMBERSHIP_STATUSES,
   MembershipResponseSchema,
   ROLE_HIERARCHY,
@@ -50,6 +53,8 @@ export {
   leaveCommunity,
   listActiveCommunityMembers,
   listCommunityMembers,
+  listCommunityMembersPaginated,
   removeMember,
+  transferOwnership,
   updateMembership,
 } from "./service";

--- a/src/features/memberships/index.ts
+++ b/src/features/memberships/index.ts
@@ -4,12 +4,16 @@ export {
   AlreadyMemberError,
   BannedUserError,
   CannotModifyOwnerError,
+  DatabaseError,
   InsufficientPermissionsError,
   InvalidRoleAssignmentError,
+  MembershipCreationFailedError,
+  MembershipDeleteFailedError,
   MembershipError,
   MembershipNotFoundError,
   NotMemberError,
   OwnerCannotLeaveError,
+  OwnershipTransferFailedError,
 } from "./errors";
 
 // Types and Schemas

--- a/src/features/memberships/index.ts
+++ b/src/features/memberships/index.ts
@@ -1,0 +1,55 @@
+// Errors
+export type { MembershipErrorCode } from "./errors";
+export {
+  AlreadyMemberError,
+  CannotModifyOwnerError,
+  InsufficientPermissionsError,
+  InvalidRoleAssignmentError,
+  MembershipError,
+  MembershipNotFoundError,
+  NotMemberError,
+  OwnerCannotLeaveError,
+} from "./errors";
+
+// Types and Schemas
+export type { Membership, NewMembership } from "./models";
+// Permission helpers
+export {
+  canAssignRole,
+  canBanMembers,
+  canManageAdmins,
+  canManageModerators,
+  canManageRole,
+  hasMinimumRole,
+} from "./permissions";
+export type {
+  AssignableRole,
+  CommunityRole,
+  MembershipResponse,
+  MembershipStatus,
+  TransferOwnershipInput,
+  UpdateMembershipInput,
+} from "./schemas";
+export {
+  ASSIGNABLE_ROLES,
+  COMMUNITY_ROLES,
+  MEMBERSHIP_STATUSES,
+  MembershipResponseSchema,
+  ROLE_HIERARCHY,
+  TransferOwnershipSchema,
+  UpdateMembershipSchema,
+} from "./schemas";
+
+// Service functions (public API - repository is NOT exported)
+export {
+  getCommunityMemberCount,
+  getMembership,
+  getMembershipByProfileAndCommunity,
+  isMember,
+  joinCommunity,
+  leaveCommunity,
+  listActiveCommunityMembers,
+  listCommunityMembers,
+  removeMember,
+  updateMembership,
+} from "./service";

--- a/src/features/memberships/models.ts
+++ b/src/features/memberships/models.ts
@@ -1,0 +1,8 @@
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+
+import { memberships } from "@/core/database/schema";
+
+export { memberships };
+
+export type Membership = InferSelectModel<typeof memberships>;
+export type NewMembership = InferInsertModel<typeof memberships>;

--- a/src/features/memberships/permissions.ts
+++ b/src/features/memberships/permissions.ts
@@ -1,0 +1,49 @@
+import type { AssignableRole, CommunityRole } from "./schemas";
+import { ROLE_HIERARCHY } from "./schemas";
+
+/**
+ * Check if actor role can manage target role.
+ * Actor must have strictly higher hierarchy than target.
+ */
+export function canManageRole(actorRole: CommunityRole, targetRole: CommunityRole): boolean {
+  return ROLE_HIERARCHY[actorRole] > ROLE_HIERARCHY[targetRole];
+}
+
+/**
+ * Check if actor role can assign a new role.
+ * Actor must have strictly higher hierarchy than the role being assigned.
+ */
+export function canAssignRole(actorRole: CommunityRole, newRole: AssignableRole): boolean {
+  return ROLE_HIERARCHY[actorRole] > ROLE_HIERARCHY[newRole];
+}
+
+/**
+ * Check if actor has at least the minimum required role.
+ */
+export function hasMinimumRole(actorRole: CommunityRole, minimumRole: CommunityRole): boolean {
+  return ROLE_HIERARCHY[actorRole] >= ROLE_HIERARCHY[minimumRole];
+}
+
+/**
+ * Check if actor can ban members.
+ * Moderators and above can ban (but only members below their level).
+ */
+export function canBanMembers(actorRole: CommunityRole): boolean {
+  return hasMinimumRole(actorRole, "moderator");
+}
+
+/**
+ * Check if actor can manage admins.
+ * Only owner and co_owner can manage admins.
+ */
+export function canManageAdmins(actorRole: CommunityRole): boolean {
+  return hasMinimumRole(actorRole, "co_owner");
+}
+
+/**
+ * Check if actor can manage moderators.
+ * Admins and above can manage moderators.
+ */
+export function canManageModerators(actorRole: CommunityRole): boolean {
+  return hasMinimumRole(actorRole, "admin");
+}

--- a/src/features/memberships/repository.ts
+++ b/src/features/memberships/repository.ts
@@ -58,7 +58,18 @@ export async function countByCommunity(communityId: string): Promise<number> {
     .select({ count: count() })
     .from(memberships)
     .where(and(eq(memberships.communityId, communityId), eq(memberships.status, "active")));
-  return results[0]?.count ?? 0;
+
+  // Count query should always return exactly one row
+  const result = results[0];
+  if (results.length !== 1 || result === undefined) {
+    logger.error(
+      { communityId, resultCount: results.length },
+      "membership.count_unexpected_result",
+    );
+    return 0;
+  }
+
+  return result.count;
 }
 
 export async function create(data: NewMembership): Promise<Membership> {
@@ -86,11 +97,18 @@ export async function update(
   membershipId: string,
   data: Partial<Pick<Membership, "role" | "status">>,
 ): Promise<Membership | undefined> {
+  logger.info({ membershipId, updates: Object.keys(data) }, "membership.update_started");
+
   const results = await db
     .update(memberships)
     .set({ ...data, updatedAt: new Date() })
     .where(eq(memberships.membershipId, membershipId))
     .returning();
+
+  if (!results[0]) {
+    logger.warn({ membershipId }, "membership.update_no_rows_affected");
+  }
+
   return results[0];
 }
 
@@ -99,6 +117,11 @@ export async function deleteById(membershipId: string): Promise<boolean> {
     .delete(memberships)
     .where(eq(memberships.membershipId, membershipId))
     .returning();
+
+  if (results.length === 0) {
+    logger.warn({ membershipId }, "membership.delete_not_found");
+  }
+
   return results.length > 0;
 }
 

--- a/src/features/memberships/repository.ts
+++ b/src/features/memberships/repository.ts
@@ -2,9 +2,12 @@ import { and, count, desc, eq } from "drizzle-orm";
 
 import { db } from "@/core/database/client";
 import { getLogger } from "@/core/logging";
+import type { PaginationParams } from "@/shared/schemas/pagination";
+import { getOffset } from "@/shared/schemas/pagination";
 
 import type { Membership, NewMembership } from "./models";
 import { memberships } from "./models";
+import type { CommunityRole, MembershipStatus } from "./schemas";
 
 const logger = getLogger("memberships.repository");
 
@@ -35,6 +38,39 @@ export async function findByCommunity(communityId: string): Promise<Membership[]
     .from(memberships)
     .where(eq(memberships.communityId, communityId))
     .orderBy(desc(memberships.joinedAt));
+}
+
+export async function findByCommunityPaginated(
+  communityId: string,
+  params: PaginationParams,
+  filters?: { status?: MembershipStatus; role?: CommunityRole },
+): Promise<{ members: Membership[]; total: number }> {
+  const conditions = [eq(memberships.communityId, communityId)];
+
+  if (filters?.status) {
+    conditions.push(eq(memberships.status, filters.status));
+  }
+  if (filters?.role) {
+    conditions.push(eq(memberships.role, filters.role));
+  }
+
+  const whereClause = and(...conditions);
+
+  const [members, countResult] = await Promise.all([
+    db
+      .select()
+      .from(memberships)
+      .where(whereClause)
+      .orderBy(desc(memberships.joinedAt))
+      .limit(params.pageSize)
+      .offset(getOffset(params)),
+    db.select({ count: count() }).from(memberships).where(whereClause),
+  ]);
+
+  return {
+    members,
+    total: countResult[0]?.count ?? 0,
+  };
 }
 
 export async function findActiveByCommunity(communityId: string): Promise<Membership[]> {

--- a/src/features/memberships/repository.ts
+++ b/src/features/memberships/repository.ts
@@ -5,6 +5,7 @@ import { getLogger } from "@/core/logging";
 import type { PaginationParams } from "@/shared/schemas/pagination";
 import { getOffset } from "@/shared/schemas/pagination";
 
+import { DatabaseError, MembershipCreationFailedError } from "./errors";
 import type { Membership, NewMembership } from "./models";
 import { memberships } from "./models";
 import type { CommunityRole, MembershipStatus } from "./schemas";
@@ -67,9 +68,15 @@ export async function findByCommunityPaginated(
     db.select({ count: count() }).from(memberships).where(whereClause),
   ]);
 
+  const countRow = countResult[0];
+  if (!countRow) {
+    logger.error({ communityId }, "membership.paginated_count_unexpected_result");
+    throw new DatabaseError("count members");
+  }
+
   return {
     members,
-    total: countResult[0]?.count ?? 0,
+    total: countRow.count,
   };
 }
 
@@ -95,14 +102,14 @@ export async function countByCommunity(communityId: string): Promise<number> {
     .from(memberships)
     .where(and(eq(memberships.communityId, communityId), eq(memberships.status, "active")));
 
-  // Count query should always return exactly one row
+  // Drizzle count() always returns exactly one row; this guard is defensive against ORM bugs
   const result = results[0];
   if (results.length !== 1 || result === undefined) {
     logger.error(
       { communityId, resultCount: results.length },
       "membership.count_unexpected_result",
     );
-    return 0;
+    throw new DatabaseError("count community members");
   }
 
   return result.count;
@@ -122,7 +129,7 @@ export async function create(data: NewMembership): Promise<Membership> {
       { communityId: data.communityId, profileId: data.profileId },
       "membership.create_failed",
     );
-    throw new Error("Failed to create membership");
+    throw new MembershipCreationFailedError(data.communityId);
   }
 
   logger.info({ membershipId: membership.membershipId }, "membership.create_completed");

--- a/src/features/memberships/repository.ts
+++ b/src/features/memberships/repository.ts
@@ -1,0 +1,112 @@
+import { and, count, desc, eq } from "drizzle-orm";
+
+import { db } from "@/core/database/client";
+import { getLogger } from "@/core/logging";
+
+import type { Membership, NewMembership } from "./models";
+import { memberships } from "./models";
+
+const logger = getLogger("memberships.repository");
+
+export async function findById(membershipId: string): Promise<Membership | undefined> {
+  const results = await db
+    .select()
+    .from(memberships)
+    .where(eq(memberships.membershipId, membershipId))
+    .limit(1);
+  return results[0];
+}
+
+export async function findByProfileAndCommunity(
+  profileId: string,
+  communityId: string,
+): Promise<Membership | undefined> {
+  const results = await db
+    .select()
+    .from(memberships)
+    .where(and(eq(memberships.profileId, profileId), eq(memberships.communityId, communityId)))
+    .limit(1);
+  return results[0];
+}
+
+export async function findByCommunity(communityId: string): Promise<Membership[]> {
+  return db
+    .select()
+    .from(memberships)
+    .where(eq(memberships.communityId, communityId))
+    .orderBy(desc(memberships.joinedAt));
+}
+
+export async function findActiveByCommunity(communityId: string): Promise<Membership[]> {
+  return db
+    .select()
+    .from(memberships)
+    .where(and(eq(memberships.communityId, communityId), eq(memberships.status, "active")))
+    .orderBy(desc(memberships.joinedAt));
+}
+
+export async function findByProfile(profileId: string): Promise<Membership[]> {
+  return db
+    .select()
+    .from(memberships)
+    .where(eq(memberships.profileId, profileId))
+    .orderBy(desc(memberships.joinedAt));
+}
+
+export async function countByCommunity(communityId: string): Promise<number> {
+  const results = await db
+    .select({ count: count() })
+    .from(memberships)
+    .where(and(eq(memberships.communityId, communityId), eq(memberships.status, "active")));
+  return results[0]?.count ?? 0;
+}
+
+export async function create(data: NewMembership): Promise<Membership> {
+  logger.info(
+    { communityId: data.communityId, profileId: data.profileId },
+    "membership.create_started",
+  );
+
+  const results = await db.insert(memberships).values(data).returning();
+  const membership = results[0];
+
+  if (!membership) {
+    logger.error(
+      { communityId: data.communityId, profileId: data.profileId },
+      "membership.create_failed",
+    );
+    throw new Error("Failed to create membership");
+  }
+
+  logger.info({ membershipId: membership.membershipId }, "membership.create_completed");
+  return membership;
+}
+
+export async function update(
+  membershipId: string,
+  data: Partial<Pick<Membership, "role" | "status">>,
+): Promise<Membership | undefined> {
+  const results = await db
+    .update(memberships)
+    .set({ ...data, updatedAt: new Date() })
+    .where(eq(memberships.membershipId, membershipId))
+    .returning();
+  return results[0];
+}
+
+export async function deleteById(membershipId: string): Promise<boolean> {
+  const results = await db
+    .delete(memberships)
+    .where(eq(memberships.membershipId, membershipId))
+    .returning();
+  return results.length > 0;
+}
+
+export async function membershipExists(profileId: string, communityId: string): Promise<boolean> {
+  const results = await db
+    .select()
+    .from(memberships)
+    .where(and(eq(memberships.profileId, profileId), eq(memberships.communityId, communityId)))
+    .limit(1);
+  return results[0] !== undefined;
+}

--- a/src/features/memberships/schemas.ts
+++ b/src/features/memberships/schemas.ts
@@ -1,0 +1,49 @@
+import { z } from "zod/v4";
+
+/** Valid community roles in hierarchy order (highest to lowest). */
+export const COMMUNITY_ROLES = ["owner", "co_owner", "admin", "moderator", "member"] as const;
+export type CommunityRole = (typeof COMMUNITY_ROLES)[number];
+
+/** Valid membership statuses. */
+export const MEMBERSHIP_STATUSES = ["active", "pending", "banned"] as const;
+export type MembershipStatus = (typeof MEMBERSHIP_STATUSES)[number];
+
+/** Role hierarchy values - higher number = more permissions. */
+export const ROLE_HIERARCHY: Record<CommunityRole, number> = {
+  owner: 5,
+  co_owner: 4,
+  admin: 3,
+  moderator: 2,
+  member: 1,
+} as const;
+
+/** Roles that can be assigned (owner is never assigned, only transferred). */
+export const ASSIGNABLE_ROLES = ["co_owner", "admin", "moderator", "member"] as const;
+export type AssignableRole = (typeof ASSIGNABLE_ROLES)[number];
+
+export const UpdateMembershipSchema = z.object({
+  role: z.enum(ASSIGNABLE_ROLES).optional(),
+  status: z.enum(["active", "pending", "banned"]).optional(),
+});
+
+export type UpdateMembershipInput = z.infer<typeof UpdateMembershipSchema>;
+
+export const TransferOwnershipSchema = z.object({
+  newOwnerProfileId: z.string().uuid("Invalid profile ID format"),
+});
+
+export type TransferOwnershipInput = z.infer<typeof TransferOwnershipSchema>;
+
+export const MembershipResponseSchema = z.object({
+  membershipId: z.string().uuid(),
+  communityId: z.string().uuid(),
+  profileId: z.string().uuid(),
+  role: z.enum(COMMUNITY_ROLES),
+  status: z.enum(MEMBERSHIP_STATUSES),
+  invitedByProfileId: z.string().uuid().nullable(),
+  joinedAt: z.date(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type MembershipResponse = z.infer<typeof MembershipResponseSchema>;

--- a/src/features/memberships/schemas.ts
+++ b/src/features/memberships/schemas.ts
@@ -1,5 +1,7 @@
 import { z } from "zod/v4";
 
+import { PaginationParamsSchema } from "@/shared/schemas/pagination";
+
 /** Valid community roles in hierarchy order (highest to lowest). */
 export const COMMUNITY_ROLES = ["owner", "co_owner", "admin", "moderator", "member"] as const;
 export type CommunityRole = (typeof COMMUNITY_ROLES)[number];
@@ -47,3 +49,11 @@ export const MembershipResponseSchema = z.object({
 });
 
 export type MembershipResponse = z.infer<typeof MembershipResponseSchema>;
+
+/** Query params for listing community members. */
+export const ListMembersQuerySchema = PaginationParamsSchema.extend({
+  status: z.enum(MEMBERSHIP_STATUSES).optional(),
+  role: z.enum(COMMUNITY_ROLES).optional(),
+});
+
+export type ListMembersQuery = z.infer<typeof ListMembersQuerySchema>;

--- a/src/features/memberships/schemas.ts
+++ b/src/features/memberships/schemas.ts
@@ -23,7 +23,7 @@ export type AssignableRole = (typeof ASSIGNABLE_ROLES)[number];
 
 export const UpdateMembershipSchema = z.object({
   role: z.enum(ASSIGNABLE_ROLES).optional(),
-  status: z.enum(["active", "pending", "banned"]).optional(),
+  status: z.enum(MEMBERSHIP_STATUSES).optional(),
 });
 
 export type UpdateMembershipInput = z.infer<typeof UpdateMembershipSchema>;

--- a/src/features/memberships/service.ts
+++ b/src/features/memberships/service.ts
@@ -8,9 +8,11 @@ import {
   CannotModifyOwnerError,
   InsufficientPermissionsError,
   InvalidRoleAssignmentError,
+  MembershipDeleteFailedError,
   MembershipNotFoundError,
   NotMemberError,
   OwnerCannotLeaveError,
+  OwnershipTransferFailedError,
 } from "./errors";
 import type { Membership } from "./models";
 import { canAssignRole, canManageRole } from "./permissions";
@@ -175,7 +177,11 @@ export async function leaveCommunity(profileId: string, communityId: string): Pr
     throw new OwnerCannotLeaveError();
   }
 
-  await repository.deleteById(membership.membershipId);
+  const deleted = await repository.deleteById(membership.membershipId);
+  if (!deleted) {
+    logger.error({ membershipId: membership.membershipId }, "membership.leave_delete_failed");
+    throw new MembershipDeleteFailedError(membership.membershipId);
+  }
 
   logger.info({ membershipId: membership.membershipId }, "membership.leave_completed");
 }
@@ -291,7 +297,11 @@ export async function removeMember(
     throw new InsufficientPermissionsError("remove this member");
   }
 
-  await repository.deleteById(targetMembershipId);
+  const deleted = await repository.deleteById(targetMembershipId);
+  if (!deleted) {
+    logger.error({ membershipId: targetMembershipId }, "membership.remove_delete_failed");
+    throw new MembershipDeleteFailedError(targetMembershipId);
+  }
 
   logger.info({ membershipId: targetMembershipId }, "membership.remove_completed");
 }
@@ -329,6 +339,7 @@ export async function transferOwnership(
     communityId,
   );
   if (!currentOwnerMembership) {
+    logger.warn({ currentOwnerProfileId, communityId }, "membership.current_owner_not_member");
     throw new NotMemberError(communityId);
   }
   if (currentOwnerMembership.role !== "owner") {
@@ -364,7 +375,7 @@ export async function transferOwnership(
 
   if (!updatedOldOwner || !updatedNewOwner) {
     logger.error({ communityId }, "membership.transfer_failed");
-    throw new Error("Failed to transfer ownership");
+    throw new OwnershipTransferFailedError(communityId);
   }
 
   logger.info(

--- a/src/features/memberships/service.ts
+++ b/src/features/memberships/service.ts
@@ -1,0 +1,278 @@
+import { getLogger } from "@/core/logging";
+
+import {
+  AlreadyMemberError,
+  CannotModifyOwnerError,
+  InsufficientPermissionsError,
+  InvalidRoleAssignmentError,
+  MembershipNotFoundError,
+  NotMemberError,
+  OwnerCannotLeaveError,
+} from "./errors";
+import type { Membership } from "./models";
+import { canAssignRole, canManageRole } from "./permissions";
+import * as repository from "./repository";
+import type { MembershipStatus, UpdateMembershipInput } from "./schemas";
+
+const logger = getLogger("memberships.service");
+
+/**
+ * Get a membership by ID.
+ */
+export async function getMembership(membershipId: string): Promise<Membership> {
+  logger.info({ membershipId }, "membership.get_started");
+
+  const membership = await repository.findById(membershipId);
+
+  if (!membership) {
+    logger.warn({ membershipId }, "membership.get_failed");
+    throw new MembershipNotFoundError(membershipId);
+  }
+
+  logger.info({ membershipId }, "membership.get_completed");
+  return membership;
+}
+
+/**
+ * Get membership for a profile in a community.
+ */
+export async function getMembershipByProfileAndCommunity(
+  profileId: string,
+  communityId: string,
+): Promise<Membership> {
+  logger.info({ profileId, communityId }, "membership.get_by_profile_community_started");
+
+  const membership = await repository.findByProfileAndCommunity(profileId, communityId);
+
+  if (!membership) {
+    logger.warn({ profileId, communityId }, "membership.get_by_profile_community_failed");
+    throw new NotMemberError(communityId);
+  }
+
+  logger.info(
+    { membershipId: membership.membershipId },
+    "membership.get_by_profile_community_completed",
+  );
+  return membership;
+}
+
+/**
+ * List all members of a community.
+ */
+export async function listCommunityMembers(communityId: string): Promise<Membership[]> {
+  logger.info({ communityId }, "membership.list_started");
+
+  const members = await repository.findByCommunity(communityId);
+
+  logger.info({ communityId, count: members.length }, "membership.list_completed");
+  return members;
+}
+
+/**
+ * List active members of a community.
+ */
+export async function listActiveCommunityMembers(communityId: string): Promise<Membership[]> {
+  logger.info({ communityId }, "membership.list_active_started");
+
+  const members = await repository.findActiveByCommunity(communityId);
+
+  logger.info({ communityId, count: members.length }, "membership.list_active_completed");
+  return members;
+}
+
+/**
+ * Get member count for a community.
+ */
+export async function getCommunityMemberCount(communityId: string): Promise<number> {
+  logger.info({ communityId }, "membership.count_started");
+
+  const memberCount = await repository.countByCommunity(communityId);
+
+  logger.info({ communityId, count: memberCount }, "membership.count_completed");
+  return memberCount;
+}
+
+/**
+ * Join a community.
+ * Public communities: status = active
+ * Private communities: status = pending (requires approval)
+ */
+export async function joinCommunity(
+  profileId: string,
+  communityId: string,
+  communityVisibility: "public" | "private" | "paid",
+): Promise<Membership> {
+  logger.info({ profileId, communityId }, "membership.join_started");
+
+  // Check if already a member
+  const existing = await repository.findByProfileAndCommunity(profileId, communityId);
+  if (existing) {
+    logger.warn({ profileId, communityId }, "membership.already_member");
+    throw new AlreadyMemberError(communityId);
+  }
+
+  // Determine initial status based on community visibility
+  const status: MembershipStatus = communityVisibility === "public" ? "active" : "pending";
+
+  const membership = await repository.create({
+    communityId,
+    profileId,
+    role: "member",
+    status,
+  });
+
+  logger.info({ membershipId: membership.membershipId, status }, "membership.join_completed");
+  return membership;
+}
+
+/**
+ * Leave a community.
+ * Owner cannot leave - must transfer ownership first.
+ */
+export async function leaveCommunity(profileId: string, communityId: string): Promise<void> {
+  logger.info({ profileId, communityId }, "membership.leave_started");
+
+  const membership = await repository.findByProfileAndCommunity(profileId, communityId);
+
+  if (!membership) {
+    logger.warn({ profileId, communityId }, "membership.not_member");
+    throw new NotMemberError(communityId);
+  }
+
+  if (membership.role === "owner") {
+    logger.warn({ profileId, communityId }, "membership.owner_cannot_leave");
+    throw new OwnerCannotLeaveError();
+  }
+
+  await repository.deleteById(membership.membershipId);
+
+  logger.info({ membershipId: membership.membershipId }, "membership.leave_completed");
+}
+
+/**
+ * Update a membership (role or status).
+ * Enforces role hierarchy permissions.
+ */
+export async function updateMembership(
+  targetMembershipId: string,
+  input: UpdateMembershipInput,
+  actorProfileId: string,
+  communityId: string,
+): Promise<Membership> {
+  logger.info({ targetMembershipId, actorProfileId }, "membership.update_started");
+
+  // Get actor's membership to check permissions
+  const actorMembership = await repository.findByProfileAndCommunity(actorProfileId, communityId);
+  if (!actorMembership || actorMembership.status !== "active") {
+    logger.warn({ actorProfileId, communityId }, "membership.actor_not_active_member");
+    throw new InsufficientPermissionsError("update membership");
+  }
+
+  // Get target membership
+  const targetMembership = await repository.findById(targetMembershipId);
+  if (!targetMembership) {
+    logger.warn({ targetMembershipId }, "membership.target_not_found");
+    throw new MembershipNotFoundError(targetMembershipId);
+  }
+
+  // Cannot modify owner
+  if (targetMembership.role === "owner") {
+    logger.warn({ targetMembershipId }, "membership.cannot_modify_owner");
+    throw new CannotModifyOwnerError();
+  }
+
+  // Check if actor can manage target based on role hierarchy
+  if (!canManageRole(actorMembership.role, targetMembership.role)) {
+    logger.warn(
+      { actorRole: actorMembership.role, targetRole: targetMembership.role },
+      "membership.insufficient_hierarchy",
+    );
+    throw new InsufficientPermissionsError("manage this member");
+  }
+
+  // If changing role, validate the new role
+  if (input.role !== undefined) {
+    if (!canAssignRole(actorMembership.role, input.role)) {
+      logger.warn(
+        { actorRole: actorMembership.role, newRole: input.role },
+        "membership.cannot_assign_role",
+      );
+      throw new InvalidRoleAssignmentError(input.role);
+    }
+  }
+
+  // Build update data for exactOptionalPropertyTypes
+  const updateData: Partial<Pick<Membership, "role" | "status">> = {};
+  if (input.role !== undefined) {
+    updateData.role = input.role;
+  }
+  if (input.status !== undefined) {
+    updateData.status = input.status;
+  }
+
+  const updated = await repository.update(targetMembershipId, updateData);
+
+  if (!updated) {
+    logger.error({ targetMembershipId }, "membership.update_failed");
+    throw new MembershipNotFoundError(targetMembershipId);
+  }
+
+  logger.info({ membershipId: targetMembershipId }, "membership.update_completed");
+  return updated;
+}
+
+/**
+ * Remove a member from a community.
+ */
+export async function removeMember(
+  targetMembershipId: string,
+  actorProfileId: string,
+  communityId: string,
+): Promise<void> {
+  logger.info({ targetMembershipId, actorProfileId }, "membership.remove_started");
+
+  // Get actor's membership
+  const actorMembership = await repository.findByProfileAndCommunity(actorProfileId, communityId);
+  if (!actorMembership || actorMembership.status !== "active") {
+    logger.warn({ actorProfileId, communityId }, "membership.actor_not_active_member");
+    throw new InsufficientPermissionsError("remove member");
+  }
+
+  // Get target membership
+  const targetMembership = await repository.findById(targetMembershipId);
+  if (!targetMembership) {
+    logger.warn({ targetMembershipId }, "membership.target_not_found");
+    throw new MembershipNotFoundError(targetMembershipId);
+  }
+
+  // Cannot remove owner
+  if (targetMembership.role === "owner") {
+    logger.warn({ targetMembershipId }, "membership.cannot_remove_owner");
+    throw new CannotModifyOwnerError();
+  }
+
+  // Check hierarchy
+  if (!canManageRole(actorMembership.role, targetMembership.role)) {
+    logger.warn(
+      { actorRole: actorMembership.role, targetRole: targetMembership.role },
+      "membership.insufficient_hierarchy",
+    );
+    throw new InsufficientPermissionsError("remove this member");
+  }
+
+  await repository.deleteById(targetMembershipId);
+
+  logger.info({ membershipId: targetMembershipId }, "membership.remove_completed");
+}
+
+/**
+ * Check if a profile is a member of a community.
+ */
+export async function isMember(profileId: string, communityId: string): Promise<boolean> {
+  logger.info({ profileId, communityId }, "membership.check_started");
+
+  const exists = await repository.membershipExists(profileId, communityId);
+
+  logger.info({ profileId, communityId, isMember: exists }, "membership.check_completed");
+  return exists;
+}

--- a/src/features/memberships/service.ts
+++ b/src/features/memberships/service.ts
@@ -95,7 +95,7 @@ export async function getCommunityMemberCount(communityId: string): Promise<numb
 /**
  * Join a community.
  * Public communities: status = active
- * Private communities: status = pending (requires approval)
+ * Private/Paid communities: status = pending (requires approval)
  */
 export async function joinCommunity(
   profileId: string,
@@ -266,7 +266,8 @@ export async function removeMember(
 }
 
 /**
- * Check if a profile is a member of a community.
+ * Check if a membership record exists for a profile in a community.
+ * Note: Returns true for any membership status (active, pending, or banned).
  */
 export async function isMember(profileId: string, communityId: string): Promise<boolean> {
   logger.info({ profileId, communityId }, "membership.check_started");

--- a/src/features/memberships/service.ts
+++ b/src/features/memberships/service.ts
@@ -1,7 +1,10 @@
 import { getLogger } from "@/core/logging";
+import type { PaginatedResponse, PaginationParams } from "@/shared/schemas/pagination";
+import { createPaginatedResponse } from "@/shared/schemas/pagination";
 
 import {
   AlreadyMemberError,
+  BannedUserError,
   CannotModifyOwnerError,
   InsufficientPermissionsError,
   InvalidRoleAssignmentError,
@@ -12,7 +15,7 @@ import {
 import type { Membership } from "./models";
 import { canAssignRole, canManageRole } from "./permissions";
 import * as repository from "./repository";
-import type { MembershipStatus, UpdateMembershipInput } from "./schemas";
+import type { CommunityRole, MembershipStatus, UpdateMembershipInput } from "./schemas";
 
 const logger = getLogger("memberships.service");
 
@@ -35,10 +38,12 @@ export async function getMembership(membershipId: string): Promise<Membership> {
 
 /**
  * Get membership for a profile in a community.
+ * Throws BannedUserError if user is banned (unless throwOnBanned is false).
  */
 export async function getMembershipByProfileAndCommunity(
   profileId: string,
   communityId: string,
+  options?: { throwOnBanned?: boolean },
 ): Promise<Membership> {
   logger.info({ profileId, communityId }, "membership.get_by_profile_community_started");
 
@@ -47,6 +52,12 @@ export async function getMembershipByProfileAndCommunity(
   if (!membership) {
     logger.warn({ profileId, communityId }, "membership.get_by_profile_community_failed");
     throw new NotMemberError(communityId);
+  }
+
+  // Check if user is banned
+  if (options?.throwOnBanned !== false && membership.status === "banned") {
+    logger.warn({ profileId, communityId }, "membership.user_banned");
+    throw new BannedUserError(communityId);
   }
 
   logger.info(
@@ -66,6 +77,26 @@ export async function listCommunityMembers(communityId: string): Promise<Members
 
   logger.info({ communityId, count: members.length }, "membership.list_completed");
   return members;
+}
+
+/**
+ * List members of a community with pagination and optional filters.
+ */
+export async function listCommunityMembersPaginated(
+  communityId: string,
+  params: PaginationParams,
+  filters?: { status?: MembershipStatus; role?: CommunityRole },
+): Promise<PaginatedResponse<Membership>> {
+  logger.info({ communityId, page: params.page }, "membership.list_paginated_started");
+
+  const { members, total } = await repository.findByCommunityPaginated(
+    communityId,
+    params,
+    filters,
+  );
+
+  logger.info({ communityId, count: members.length, total }, "membership.list_paginated_completed");
+  return createPaginatedResponse(members, total, params);
 }
 
 /**
@@ -276,4 +307,77 @@ export async function isMember(profileId: string, communityId: string): Promise<
 
   logger.info({ profileId, communityId, isMember: exists }, "membership.check_completed");
   return exists;
+}
+
+/**
+ * Transfer community ownership to another active member.
+ * Current owner becomes co_owner, new owner gets owner role.
+ */
+export async function transferOwnership(
+  communityId: string,
+  currentOwnerProfileId: string,
+  newOwnerProfileId: string,
+): Promise<{ oldOwnerMembership: Membership; newOwnerMembership: Membership }> {
+  logger.info(
+    { communityId, currentOwnerProfileId, newOwnerProfileId },
+    "membership.transfer_started",
+  );
+
+  // Get current owner's membership
+  const currentOwnerMembership = await repository.findByProfileAndCommunity(
+    currentOwnerProfileId,
+    communityId,
+  );
+  if (!currentOwnerMembership) {
+    throw new NotMemberError(communityId);
+  }
+  if (currentOwnerMembership.role !== "owner") {
+    logger.warn(
+      { currentOwnerProfileId, role: currentOwnerMembership.role },
+      "membership.not_owner",
+    );
+    throw new InsufficientPermissionsError("transfer ownership");
+  }
+
+  // Get new owner's membership
+  const newOwnerMembership = await repository.findByProfileAndCommunity(
+    newOwnerProfileId,
+    communityId,
+  );
+  if (!newOwnerMembership) {
+    logger.warn({ newOwnerProfileId }, "membership.new_owner_not_member");
+    throw new NotMemberError(communityId);
+  }
+  if (newOwnerMembership.status !== "active") {
+    logger.warn(
+      { newOwnerProfileId, status: newOwnerMembership.status },
+      "membership.new_owner_not_active",
+    );
+    throw new InsufficientPermissionsError("transfer to non-active member");
+  }
+
+  // Perform transfer: demote current owner to co_owner, promote new owner to owner
+  const [updatedOldOwner, updatedNewOwner] = await Promise.all([
+    repository.update(currentOwnerMembership.membershipId, { role: "co_owner" }),
+    repository.update(newOwnerMembership.membershipId, { role: "owner" }),
+  ]);
+
+  if (!updatedOldOwner || !updatedNewOwner) {
+    logger.error({ communityId }, "membership.transfer_failed");
+    throw new Error("Failed to transfer ownership");
+  }
+
+  logger.info(
+    {
+      communityId,
+      oldOwner: currentOwnerProfileId,
+      newOwner: newOwnerProfileId,
+    },
+    "membership.transfer_completed",
+  );
+
+  return {
+    oldOwnerMembership: updatedOldOwner,
+    newOwnerMembership: updatedNewOwner,
+  };
 }

--- a/src/features/memberships/tests/errors.test.ts
+++ b/src/features/memberships/tests/errors.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  AlreadyMemberError,
+  CannotModifyOwnerError,
+  InsufficientPermissionsError,
+  InvalidRoleAssignmentError,
+  MembershipError,
+  MembershipNotFoundError,
+  NotMemberError,
+  OwnerCannotLeaveError,
+} from "../errors";
+
+describe("MembershipError", () => {
+  it("creates error with message, code, and status", () => {
+    const error = new MembershipError("Test error", "MEMBERSHIP_NOT_FOUND", 404);
+    expect(error.message).toBe("Test error");
+    expect(error.code).toBe("MEMBERSHIP_NOT_FOUND");
+    expect(error.statusCode).toBe(404);
+    expect(error.name).toBe("MembershipError");
+  });
+
+  it("is instanceof Error", () => {
+    const error = new MembershipError("Test", "MEMBERSHIP_NOT_FOUND", 404);
+    expect(error).toBeInstanceOf(Error);
+  });
+});
+
+describe("MembershipNotFoundError", () => {
+  it("creates error with correct defaults", () => {
+    const error = new MembershipNotFoundError("membership-123");
+    expect(error.message).toBe("Membership not found: membership-123");
+    expect(error.code).toBe("MEMBERSHIP_NOT_FOUND");
+    expect(error.statusCode).toBe(404);
+  });
+});
+
+describe("AlreadyMemberError", () => {
+  it("creates error with correct defaults", () => {
+    const error = new AlreadyMemberError("community-123");
+    expect(error.message).toBe("Already a member of community: community-123");
+    expect(error.code).toBe("ALREADY_MEMBER");
+    expect(error.statusCode).toBe(409);
+  });
+});
+
+describe("NotMemberError", () => {
+  it("creates error with correct defaults", () => {
+    const error = new NotMemberError("community-123");
+    expect(error.message).toBe("Not a member of community: community-123");
+    expect(error.code).toBe("NOT_MEMBER");
+    expect(error.statusCode).toBe(404);
+  });
+});
+
+describe("InsufficientPermissionsError", () => {
+  it("creates error with correct defaults", () => {
+    const error = new InsufficientPermissionsError("update membership");
+    expect(error.message).toBe("Insufficient permissions to: update membership");
+    expect(error.code).toBe("INSUFFICIENT_PERMISSIONS");
+    expect(error.statusCode).toBe(403);
+  });
+});
+
+describe("CannotModifyOwnerError", () => {
+  it("creates error with correct defaults", () => {
+    const error = new CannotModifyOwnerError();
+    expect(error.message).toBe("Cannot modify the community owner");
+    expect(error.code).toBe("CANNOT_MODIFY_OWNER");
+    expect(error.statusCode).toBe(403);
+  });
+});
+
+describe("OwnerCannotLeaveError", () => {
+  it("creates error with correct defaults", () => {
+    const error = new OwnerCannotLeaveError();
+    expect(error.message).toBe("Owner cannot leave community. Transfer ownership first.");
+    expect(error.code).toBe("OWNER_CANNOT_LEAVE");
+    expect(error.statusCode).toBe(403);
+  });
+});
+
+describe("InvalidRoleAssignmentError", () => {
+  it("creates error with correct defaults", () => {
+    const error = new InvalidRoleAssignmentError("owner");
+    expect(error.message).toBe("Cannot assign role: owner");
+    expect(error.code).toBe("INVALID_ROLE_ASSIGNMENT");
+    expect(error.statusCode).toBe(403);
+  });
+});

--- a/src/features/memberships/tests/errors.test.ts
+++ b/src/features/memberships/tests/errors.test.ts
@@ -2,13 +2,18 @@ import { describe, expect, it } from "bun:test";
 
 import {
   AlreadyMemberError,
+  BannedUserError,
   CannotModifyOwnerError,
+  DatabaseError,
   InsufficientPermissionsError,
   InvalidRoleAssignmentError,
+  MembershipCreationFailedError,
+  MembershipDeleteFailedError,
   MembershipError,
   MembershipNotFoundError,
   NotMemberError,
   OwnerCannotLeaveError,
+  OwnershipTransferFailedError,
 } from "../errors";
 
 describe("MembershipError", () => {
@@ -86,5 +91,50 @@ describe("InvalidRoleAssignmentError", () => {
     expect(error.message).toBe("Cannot assign role: owner");
     expect(error.code).toBe("INVALID_ROLE_ASSIGNMENT");
     expect(error.statusCode).toBe(403);
+  });
+});
+
+describe("BannedUserError", () => {
+  it("creates error with correct defaults", () => {
+    const error = new BannedUserError("community-123");
+    expect(error.message).toBe("User is banned from community: community-123");
+    expect(error.code).toBe("USER_BANNED");
+    expect(error.statusCode).toBe(403);
+  });
+});
+
+describe("MembershipCreationFailedError", () => {
+  it("creates error with correct defaults", () => {
+    const error = new MembershipCreationFailedError("community-123");
+    expect(error.message).toBe("Failed to create membership for community: community-123");
+    expect(error.code).toBe("MEMBERSHIP_CREATION_FAILED");
+    expect(error.statusCode).toBe(500);
+  });
+});
+
+describe("OwnershipTransferFailedError", () => {
+  it("creates error with correct defaults", () => {
+    const error = new OwnershipTransferFailedError("community-123");
+    expect(error.message).toBe("Failed to transfer ownership for community: community-123");
+    expect(error.code).toBe("OWNERSHIP_TRANSFER_FAILED");
+    expect(error.statusCode).toBe(500);
+  });
+});
+
+describe("MembershipDeleteFailedError", () => {
+  it("creates error with correct defaults", () => {
+    const error = new MembershipDeleteFailedError("membership-123");
+    expect(error.message).toBe("Failed to delete membership: membership-123");
+    expect(error.code).toBe("MEMBERSHIP_DELETE_FAILED");
+    expect(error.statusCode).toBe(500);
+  });
+});
+
+describe("DatabaseError", () => {
+  it("creates error with correct defaults", () => {
+    const error = new DatabaseError("count members");
+    expect(error.message).toBe("Database error during: count members");
+    expect(error.code).toBe("DATABASE_ERROR");
+    expect(error.statusCode).toBe(500);
   });
 });

--- a/src/features/memberships/tests/permissions.test.ts
+++ b/src/features/memberships/tests/permissions.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  canAssignRole,
+  canBanMembers,
+  canManageAdmins,
+  canManageModerators,
+  canManageRole,
+  hasMinimumRole,
+} from "../permissions";
+
+describe("canManageRole", () => {
+  it("owner can manage all other roles", () => {
+    expect(canManageRole("owner", "co_owner")).toBe(true);
+    expect(canManageRole("owner", "admin")).toBe(true);
+    expect(canManageRole("owner", "moderator")).toBe(true);
+    expect(canManageRole("owner", "member")).toBe(true);
+  });
+
+  it("owner cannot manage owner", () => {
+    expect(canManageRole("owner", "owner")).toBe(false);
+  });
+
+  it("co_owner can manage admin, moderator, member", () => {
+    expect(canManageRole("co_owner", "admin")).toBe(true);
+    expect(canManageRole("co_owner", "moderator")).toBe(true);
+    expect(canManageRole("co_owner", "member")).toBe(true);
+  });
+
+  it("co_owner cannot manage owner or co_owner", () => {
+    expect(canManageRole("co_owner", "owner")).toBe(false);
+    expect(canManageRole("co_owner", "co_owner")).toBe(false);
+  });
+
+  it("admin can manage moderator and member", () => {
+    expect(canManageRole("admin", "moderator")).toBe(true);
+    expect(canManageRole("admin", "member")).toBe(true);
+  });
+
+  it("admin cannot manage owner, co_owner, or admin", () => {
+    expect(canManageRole("admin", "owner")).toBe(false);
+    expect(canManageRole("admin", "co_owner")).toBe(false);
+    expect(canManageRole("admin", "admin")).toBe(false);
+  });
+
+  it("moderator can manage member", () => {
+    expect(canManageRole("moderator", "member")).toBe(true);
+  });
+
+  it("moderator cannot manage owner, co_owner, admin, or moderator", () => {
+    expect(canManageRole("moderator", "owner")).toBe(false);
+    expect(canManageRole("moderator", "co_owner")).toBe(false);
+    expect(canManageRole("moderator", "admin")).toBe(false);
+    expect(canManageRole("moderator", "moderator")).toBe(false);
+  });
+
+  it("member cannot manage anyone", () => {
+    expect(canManageRole("member", "owner")).toBe(false);
+    expect(canManageRole("member", "co_owner")).toBe(false);
+    expect(canManageRole("member", "admin")).toBe(false);
+    expect(canManageRole("member", "moderator")).toBe(false);
+    expect(canManageRole("member", "member")).toBe(false);
+  });
+});
+
+describe("canAssignRole", () => {
+  it("owner can assign co_owner, admin, moderator, member", () => {
+    expect(canAssignRole("owner", "co_owner")).toBe(true);
+    expect(canAssignRole("owner", "admin")).toBe(true);
+    expect(canAssignRole("owner", "moderator")).toBe(true);
+    expect(canAssignRole("owner", "member")).toBe(true);
+  });
+
+  it("co_owner can assign admin, moderator, member", () => {
+    expect(canAssignRole("co_owner", "admin")).toBe(true);
+    expect(canAssignRole("co_owner", "moderator")).toBe(true);
+    expect(canAssignRole("co_owner", "member")).toBe(true);
+  });
+
+  it("co_owner cannot assign co_owner", () => {
+    expect(canAssignRole("co_owner", "co_owner")).toBe(false);
+  });
+
+  it("admin can assign moderator, member", () => {
+    expect(canAssignRole("admin", "moderator")).toBe(true);
+    expect(canAssignRole("admin", "member")).toBe(true);
+  });
+
+  it("admin cannot assign co_owner or admin", () => {
+    expect(canAssignRole("admin", "co_owner")).toBe(false);
+    expect(canAssignRole("admin", "admin")).toBe(false);
+  });
+
+  it("moderator can assign member", () => {
+    expect(canAssignRole("moderator", "member")).toBe(true);
+  });
+
+  it("moderator cannot assign moderator or above", () => {
+    expect(canAssignRole("moderator", "co_owner")).toBe(false);
+    expect(canAssignRole("moderator", "admin")).toBe(false);
+    expect(canAssignRole("moderator", "moderator")).toBe(false);
+  });
+
+  it("member cannot assign any role", () => {
+    expect(canAssignRole("member", "co_owner")).toBe(false);
+    expect(canAssignRole("member", "admin")).toBe(false);
+    expect(canAssignRole("member", "moderator")).toBe(false);
+    expect(canAssignRole("member", "member")).toBe(false);
+  });
+});
+
+describe("hasMinimumRole", () => {
+  it("owner has all roles", () => {
+    expect(hasMinimumRole("owner", "owner")).toBe(true);
+    expect(hasMinimumRole("owner", "co_owner")).toBe(true);
+    expect(hasMinimumRole("owner", "admin")).toBe(true);
+    expect(hasMinimumRole("owner", "moderator")).toBe(true);
+    expect(hasMinimumRole("owner", "member")).toBe(true);
+  });
+
+  it("member has only member role", () => {
+    expect(hasMinimumRole("member", "owner")).toBe(false);
+    expect(hasMinimumRole("member", "co_owner")).toBe(false);
+    expect(hasMinimumRole("member", "admin")).toBe(false);
+    expect(hasMinimumRole("member", "moderator")).toBe(false);
+    expect(hasMinimumRole("member", "member")).toBe(true);
+  });
+});
+
+describe("canBanMembers", () => {
+  it("moderator and above can ban", () => {
+    expect(canBanMembers("owner")).toBe(true);
+    expect(canBanMembers("co_owner")).toBe(true);
+    expect(canBanMembers("admin")).toBe(true);
+    expect(canBanMembers("moderator")).toBe(true);
+  });
+
+  it("member cannot ban", () => {
+    expect(canBanMembers("member")).toBe(false);
+  });
+});
+
+describe("canManageAdmins", () => {
+  it("owner and co_owner can manage admins", () => {
+    expect(canManageAdmins("owner")).toBe(true);
+    expect(canManageAdmins("co_owner")).toBe(true);
+  });
+
+  it("admin and below cannot manage admins", () => {
+    expect(canManageAdmins("admin")).toBe(false);
+    expect(canManageAdmins("moderator")).toBe(false);
+    expect(canManageAdmins("member")).toBe(false);
+  });
+});
+
+describe("canManageModerators", () => {
+  it("admin and above can manage moderators", () => {
+    expect(canManageModerators("owner")).toBe(true);
+    expect(canManageModerators("co_owner")).toBe(true);
+    expect(canManageModerators("admin")).toBe(true);
+  });
+
+  it("moderator and below cannot manage moderators", () => {
+    expect(canManageModerators("moderator")).toBe(false);
+    expect(canManageModerators("member")).toBe(false);
+  });
+});

--- a/src/features/memberships/tests/schemas.test.ts
+++ b/src/features/memberships/tests/schemas.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  MembershipResponseSchema,
+  TransferOwnershipSchema,
+  UpdateMembershipSchema,
+} from "../schemas";
+
+describe("UpdateMembershipSchema", () => {
+  it("accepts valid complete input", () => {
+    const input = {
+      role: "admin",
+      status: "active",
+    };
+    const result = UpdateMembershipSchema.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts partial input (all fields optional)", () => {
+    const result = UpdateMembershipSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts role-only update", () => {
+    const result = UpdateMembershipSchema.safeParse({ role: "moderator" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts status-only update", () => {
+    const result = UpdateMembershipSchema.safeParse({ status: "banned" });
+    expect(result.success).toBe(true);
+  });
+
+  describe("role validation", () => {
+    it("rejects owner role", () => {
+      const result = UpdateMembershipSchema.safeParse({ role: "owner" });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts co_owner role", () => {
+      const result = UpdateMembershipSchema.safeParse({ role: "co_owner" });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts admin role", () => {
+      const result = UpdateMembershipSchema.safeParse({ role: "admin" });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts moderator role", () => {
+      const result = UpdateMembershipSchema.safeParse({ role: "moderator" });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts member role", () => {
+      const result = UpdateMembershipSchema.safeParse({ role: "member" });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects invalid role", () => {
+      const result = UpdateMembershipSchema.safeParse({ role: "superadmin" });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("status validation", () => {
+    it("accepts active status", () => {
+      const result = UpdateMembershipSchema.safeParse({ status: "active" });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts pending status", () => {
+      const result = UpdateMembershipSchema.safeParse({ status: "pending" });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts banned status", () => {
+      const result = UpdateMembershipSchema.safeParse({ status: "banned" });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects invalid status", () => {
+      const result = UpdateMembershipSchema.safeParse({ status: "suspended" });
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe("TransferOwnershipSchema", () => {
+  it("accepts valid UUID", () => {
+    const result = TransferOwnershipSchema.safeParse({
+      newOwnerProfileId: "550e8400-e29b-41d4-a716-446655440000",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing newOwnerProfileId", () => {
+    const result = TransferOwnershipSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid UUID format", () => {
+    const result = TransferOwnershipSchema.safeParse({
+      newOwnerProfileId: "not-a-uuid",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("MembershipResponseSchema", () => {
+  it("validates complete membership response", () => {
+    const membership = {
+      membershipId: "550e8400-e29b-41d4-a716-446655440000",
+      communityId: "550e8400-e29b-41d4-a716-446655440001",
+      profileId: "550e8400-e29b-41d4-a716-446655440002",
+      role: "member" as const,
+      status: "active" as const,
+      invitedByProfileId: null,
+      joinedAt: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const result = MembershipResponseSchema.safeParse(membership);
+    expect(result.success).toBe(true);
+  });
+
+  it("validates membership with invitedByProfileId", () => {
+    const membership = {
+      membershipId: "550e8400-e29b-41d4-a716-446655440000",
+      communityId: "550e8400-e29b-41d4-a716-446655440001",
+      profileId: "550e8400-e29b-41d4-a716-446655440002",
+      role: "admin" as const,
+      status: "active" as const,
+      invitedByProfileId: "550e8400-e29b-41d4-a716-446655440003",
+      joinedAt: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const result = MembershipResponseSchema.safeParse(membership);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid role in response", () => {
+    const membership = {
+      membershipId: "550e8400-e29b-41d4-a716-446655440000",
+      communityId: "550e8400-e29b-41d4-a716-446655440001",
+      profileId: "550e8400-e29b-41d4-a716-446655440002",
+      role: "superadmin",
+      status: "active",
+      invitedByProfileId: null,
+      joinedAt: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const result = MembershipResponseSchema.safeParse(membership);
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/features/memberships/tests/service.test.ts
+++ b/src/features/memberships/tests/service.test.ts
@@ -55,8 +55,18 @@ const mockRepository = {
 mock.module("../repository", () => mockRepository);
 
 // Import service after mocking
-const { getMembership, joinCommunity, leaveCommunity, updateMembership, removeMember, isMember } =
-  await import("../service");
+const {
+  getMembership,
+  getMembershipByProfileAndCommunity,
+  listCommunityMembers,
+  listActiveCommunityMembers,
+  getCommunityMemberCount,
+  joinCommunity,
+  leaveCommunity,
+  updateMembership,
+  removeMember,
+  isMember,
+} = await import("../service");
 
 describe("getMembership", () => {
   beforeEach(() => {
@@ -76,6 +86,106 @@ describe("getMembership", () => {
     mockRepository.findById.mockResolvedValue(undefined);
 
     await expect(getMembership("non-existent-id")).rejects.toThrow("Membership not found");
+  });
+});
+
+describe("getMembershipByProfileAndCommunity", () => {
+  beforeEach(() => {
+    mockRepository.findByProfileAndCommunity.mockReset();
+  });
+
+  it("returns membership when found", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(mockMembership);
+
+    const result = await getMembershipByProfileAndCommunity(
+      mockMembership.profileId,
+      mockMembership.communityId,
+    );
+
+    expect(result).toEqual(mockMembership);
+    expect(mockRepository.findByProfileAndCommunity).toHaveBeenCalledWith(
+      mockMembership.profileId,
+      mockMembership.communityId,
+    );
+  });
+
+  it("throws NotMemberError when not found", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(undefined);
+
+    await expect(
+      getMembershipByProfileAndCommunity("non-member", mockMembership.communityId),
+    ).rejects.toThrow("Not a member");
+  });
+});
+
+describe("listCommunityMembers", () => {
+  beforeEach(() => {
+    mockRepository.findByCommunity.mockReset();
+  });
+
+  it("returns all members for community", async () => {
+    const members = [mockMembership, adminMembership];
+    mockRepository.findByCommunity.mockResolvedValue(members);
+
+    const result = await listCommunityMembers(mockMembership.communityId);
+
+    expect(result).toEqual(members);
+    expect(mockRepository.findByCommunity).toHaveBeenCalledWith(mockMembership.communityId);
+  });
+
+  it("returns empty array when no members", async () => {
+    mockRepository.findByCommunity.mockResolvedValue([]);
+
+    const result = await listCommunityMembers(mockMembership.communityId);
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("listActiveCommunityMembers", () => {
+  beforeEach(() => {
+    mockRepository.findActiveByCommunity.mockReset();
+  });
+
+  it("returns active members for community", async () => {
+    const members = [mockMembership];
+    mockRepository.findActiveByCommunity.mockResolvedValue(members);
+
+    const result = await listActiveCommunityMembers(mockMembership.communityId);
+
+    expect(result).toEqual(members);
+    expect(mockRepository.findActiveByCommunity).toHaveBeenCalledWith(mockMembership.communityId);
+  });
+
+  it("returns empty array when no active members", async () => {
+    mockRepository.findActiveByCommunity.mockResolvedValue([]);
+
+    const result = await listActiveCommunityMembers(mockMembership.communityId);
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("getCommunityMemberCount", () => {
+  beforeEach(() => {
+    mockRepository.countByCommunity.mockReset();
+  });
+
+  it("returns member count for community", async () => {
+    mockRepository.countByCommunity.mockResolvedValue(42);
+
+    const result = await getCommunityMemberCount(mockMembership.communityId);
+
+    expect(result).toBe(42);
+    expect(mockRepository.countByCommunity).toHaveBeenCalledWith(mockMembership.communityId);
+  });
+
+  it("returns 0 when no members", async () => {
+    mockRepository.countByCommunity.mockResolvedValue(0);
+
+    const result = await getCommunityMemberCount(mockMembership.communityId);
+
+    expect(result).toBe(0);
   });
 });
 
@@ -109,6 +219,20 @@ describe("joinCommunity", () => {
     mockRepository.create.mockResolvedValue({ ...mockMembership, status: "pending" });
 
     await joinCommunity(mockMembership.profileId, mockMembership.communityId, "private");
+
+    expect(mockRepository.create).toHaveBeenCalledWith({
+      communityId: mockMembership.communityId,
+      profileId: mockMembership.profileId,
+      role: "member",
+      status: "pending",
+    });
+  });
+
+  it("creates membership with pending status for paid community", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(undefined);
+    mockRepository.create.mockResolvedValue({ ...mockMembership, status: "pending" });
+
+    await joinCommunity(mockMembership.profileId, mockMembership.communityId, "paid");
 
     expect(mockRepository.create).toHaveBeenCalledWith({
       communityId: mockMembership.communityId,
@@ -238,6 +362,21 @@ describe("updateMembership", () => {
       ),
     ).rejects.toThrow("Cannot assign role");
   });
+
+  it("throws MembershipNotFoundError when update returns undefined (race condition)", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(adminMembership);
+    mockRepository.findById.mockResolvedValue(mockMembership);
+    mockRepository.update.mockResolvedValue(undefined); // Simulate concurrent deletion
+
+    await expect(
+      updateMembership(
+        mockMembership.membershipId,
+        { role: "moderator" },
+        adminMembership.profileId,
+        mockMembership.communityId,
+      ),
+    ).rejects.toThrow("Membership not found");
+  });
 });
 
 describe("removeMember", () => {
@@ -272,6 +411,37 @@ describe("removeMember", () => {
         mockMembership.communityId,
       ),
     ).rejects.toThrow("Cannot modify the community owner");
+  });
+
+  it("throws MembershipNotFoundError when target membership not found", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(adminMembership);
+    mockRepository.findById.mockResolvedValue(undefined);
+
+    await expect(
+      removeMember("non-existent", adminMembership.profileId, mockMembership.communityId),
+    ).rejects.toThrow("Membership not found");
+  });
+
+  it("throws InsufficientPermissionsError when actor cannot manage target role", async () => {
+    const coOwnerMembership = { ...mockMembership, role: "co_owner" as const };
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(adminMembership);
+    mockRepository.findById.mockResolvedValue(coOwnerMembership);
+
+    await expect(
+      removeMember(
+        coOwnerMembership.membershipId,
+        adminMembership.profileId,
+        mockMembership.communityId,
+      ),
+    ).rejects.toThrow("Insufficient permissions");
+  });
+
+  it("throws InsufficientPermissionsError when actor is not active member", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(undefined);
+
+    await expect(
+      removeMember(mockMembership.membershipId, "non-member", mockMembership.communityId),
+    ).rejects.toThrow("Insufficient permissions");
   });
 });
 

--- a/src/features/memberships/tests/service.test.ts
+++ b/src/features/memberships/tests/service.test.ts
@@ -66,7 +66,22 @@ const {
   updateMembership,
   removeMember,
   isMember,
+  transferOwnership,
 } = await import("../service");
+
+const bannedMembership: Membership = {
+  ...mockMembership,
+  membershipId: "550e8400-e29b-41d4-a716-446655440012",
+  profileId: "550e8400-e29b-41d4-a716-446655440005",
+  status: "banned",
+};
+
+const coOwnerMembership: Membership = {
+  ...mockMembership,
+  membershipId: "550e8400-e29b-41d4-a716-446655440013",
+  profileId: "550e8400-e29b-41d4-a716-446655440006",
+  role: "co_owner",
+};
 
 describe("getMembership", () => {
   beforeEach(() => {
@@ -464,5 +479,187 @@ describe("isMember", () => {
     const result = await isMember("non-member", mockMembership.communityId);
 
     expect(result).toBe(false);
+  });
+});
+
+describe("getMembershipByProfileAndCommunity - banned user handling", () => {
+  beforeEach(() => {
+    mockRepository.findByProfileAndCommunity.mockReset();
+  });
+
+  it("throws BannedUserError when user is banned", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(bannedMembership);
+
+    await expect(
+      getMembershipByProfileAndCommunity(bannedMembership.profileId, bannedMembership.communityId),
+    ).rejects.toThrow("User is banned");
+  });
+
+  it("returns membership when banned user with throwOnBanned: false", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(bannedMembership);
+
+    const result = await getMembershipByProfileAndCommunity(
+      bannedMembership.profileId,
+      bannedMembership.communityId,
+      { throwOnBanned: false },
+    );
+
+    expect(result).toEqual(bannedMembership);
+  });
+});
+
+describe("leaveCommunity - delete failure handling", () => {
+  beforeEach(() => {
+    mockRepository.findByProfileAndCommunity.mockReset();
+    mockRepository.deleteById.mockReset();
+  });
+
+  it("throws MembershipDeleteFailedError when delete returns false", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(mockMembership);
+    mockRepository.deleteById.mockResolvedValue(false);
+
+    await expect(
+      leaveCommunity(mockMembership.profileId, mockMembership.communityId),
+    ).rejects.toThrow("Failed to delete membership");
+  });
+});
+
+describe("removeMember - delete failure handling", () => {
+  beforeEach(() => {
+    mockRepository.findByProfileAndCommunity.mockReset();
+    mockRepository.findById.mockReset();
+    mockRepository.deleteById.mockReset();
+  });
+
+  it("throws MembershipDeleteFailedError when delete returns false", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(adminMembership);
+    mockRepository.findById.mockResolvedValue(mockMembership);
+    mockRepository.deleteById.mockResolvedValue(false);
+
+    await expect(
+      removeMember(
+        mockMembership.membershipId,
+        adminMembership.profileId,
+        mockMembership.communityId,
+      ),
+    ).rejects.toThrow("Failed to delete membership");
+  });
+});
+
+describe("transferOwnership", () => {
+  beforeEach(() => {
+    mockRepository.findByProfileAndCommunity.mockReset();
+    mockRepository.update.mockReset();
+  });
+
+  it("transfers ownership correctly, demoting old owner to co_owner", async () => {
+    const updatedOldOwner = { ...ownerMembership, role: "co_owner" as const };
+    const updatedNewOwner = { ...coOwnerMembership, role: "owner" as const };
+
+    // First call returns owner, second call returns target member
+    mockRepository.findByProfileAndCommunity
+      .mockResolvedValueOnce(ownerMembership)
+      .mockResolvedValueOnce(coOwnerMembership);
+    mockRepository.update
+      .mockResolvedValueOnce(updatedOldOwner)
+      .mockResolvedValueOnce(updatedNewOwner);
+
+    const result = await transferOwnership(
+      mockMembership.communityId,
+      ownerMembership.profileId,
+      coOwnerMembership.profileId,
+    );
+
+    expect(result.oldOwnerMembership.role).toBe("co_owner");
+    expect(result.newOwnerMembership.role).toBe("owner");
+    expect(mockRepository.update).toHaveBeenCalledWith(ownerMembership.membershipId, {
+      role: "co_owner",
+    });
+    expect(mockRepository.update).toHaveBeenCalledWith(coOwnerMembership.membershipId, {
+      role: "owner",
+    });
+  });
+
+  it("throws NotMemberError when current owner is not a member", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(undefined);
+
+    await expect(
+      transferOwnership(
+        mockMembership.communityId,
+        ownerMembership.profileId,
+        coOwnerMembership.profileId,
+      ),
+    ).rejects.toThrow("Not a member");
+  });
+
+  it("throws InsufficientPermissionsError when caller is not owner", async () => {
+    // Return a non-owner membership for the current owner check
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(adminMembership);
+
+    await expect(
+      transferOwnership(
+        mockMembership.communityId,
+        adminMembership.profileId,
+        coOwnerMembership.profileId,
+      ),
+    ).rejects.toThrow("Insufficient permissions");
+  });
+
+  it("throws NotMemberError when new owner is not a member", async () => {
+    mockRepository.findByProfileAndCommunity
+      .mockResolvedValueOnce(ownerMembership)
+      .mockResolvedValueOnce(undefined);
+
+    await expect(
+      transferOwnership(
+        mockMembership.communityId,
+        ownerMembership.profileId,
+        "non-member-profile-id",
+      ),
+    ).rejects.toThrow("Not a member");
+  });
+
+  it("throws InsufficientPermissionsError when new owner is not active", async () => {
+    const pendingMembership = { ...coOwnerMembership, status: "pending" as const };
+    mockRepository.findByProfileAndCommunity
+      .mockResolvedValueOnce(ownerMembership)
+      .mockResolvedValueOnce(pendingMembership);
+
+    await expect(
+      transferOwnership(
+        mockMembership.communityId,
+        ownerMembership.profileId,
+        pendingMembership.profileId,
+      ),
+    ).rejects.toThrow("Insufficient permissions");
+  });
+
+  it("throws InsufficientPermissionsError when new owner is banned", async () => {
+    mockRepository.findByProfileAndCommunity
+      .mockResolvedValueOnce(ownerMembership)
+      .mockResolvedValueOnce(bannedMembership);
+
+    await expect(
+      transferOwnership(
+        mockMembership.communityId,
+        ownerMembership.profileId,
+        bannedMembership.profileId,
+      ),
+    ).rejects.toThrow("Insufficient permissions");
+  });
+
+  it("throws OwnershipTransferFailedError when update fails", async () => {
+    mockRepository.findByProfileAndCommunity
+      .mockResolvedValueOnce(ownerMembership)
+      .mockResolvedValueOnce(coOwnerMembership);
+    mockRepository.update.mockResolvedValue(undefined);
+
+    await expect(
+      transferOwnership(
+        mockMembership.communityId,
+        ownerMembership.profileId,
+        coOwnerMembership.profileId,
+      ),
+    ).rejects.toThrow("Failed to transfer ownership");
   });
 });

--- a/src/features/memberships/tests/service.test.ts
+++ b/src/features/memberships/tests/service.test.ts
@@ -1,0 +1,298 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+import type { Membership } from "../models";
+
+const mockMembership: Membership = {
+  membershipId: "550e8400-e29b-41d4-a716-446655440000",
+  communityId: "550e8400-e29b-41d4-a716-446655440001",
+  profileId: "550e8400-e29b-41d4-a716-446655440002",
+  role: "member",
+  status: "active",
+  invitedByProfileId: null,
+  joinedAt: new Date(),
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const ownerMembership: Membership = {
+  ...mockMembership,
+  membershipId: "550e8400-e29b-41d4-a716-446655440010",
+  profileId: "550e8400-e29b-41d4-a716-446655440003",
+  role: "owner",
+};
+
+const adminMembership: Membership = {
+  ...mockMembership,
+  membershipId: "550e8400-e29b-41d4-a716-446655440011",
+  profileId: "550e8400-e29b-41d4-a716-446655440004",
+  role: "admin",
+};
+
+// Mock the repository module with properly typed functions
+const mockRepository = {
+  findById: mock<(membershipId: string) => Promise<Membership | undefined>>(() =>
+    Promise.resolve(undefined),
+  ),
+  findByProfileAndCommunity: mock<
+    (profileId: string, communityId: string) => Promise<Membership | undefined>
+  >(() => Promise.resolve(undefined)),
+  findByCommunity: mock<(communityId: string) => Promise<Membership[]>>(() => Promise.resolve([])),
+  findActiveByCommunity: mock<(communityId: string) => Promise<Membership[]>>(() =>
+    Promise.resolve([]),
+  ),
+  countByCommunity: mock<(communityId: string) => Promise<number>>(() => Promise.resolve(0)),
+  create: mock<(data: unknown) => Promise<Membership>>(() => Promise.resolve(mockMembership)),
+  update: mock<(membershipId: string, data: unknown) => Promise<Membership | undefined>>(() =>
+    Promise.resolve(undefined),
+  ),
+  deleteById: mock<(membershipId: string) => Promise<boolean>>(() => Promise.resolve(true)),
+  membershipExists: mock<(profileId: string, communityId: string) => Promise<boolean>>(() =>
+    Promise.resolve(false),
+  ),
+};
+
+// Mock the repository before importing service
+mock.module("../repository", () => mockRepository);
+
+// Import service after mocking
+const { getMembership, joinCommunity, leaveCommunity, updateMembership, removeMember, isMember } =
+  await import("../service");
+
+describe("getMembership", () => {
+  beforeEach(() => {
+    mockRepository.findById.mockReset();
+  });
+
+  it("returns membership when found", async () => {
+    mockRepository.findById.mockResolvedValue(mockMembership);
+
+    const result = await getMembership(mockMembership.membershipId);
+
+    expect(result).toEqual(mockMembership);
+    expect(mockRepository.findById).toHaveBeenCalledWith(mockMembership.membershipId);
+  });
+
+  it("throws MembershipNotFoundError when not found", async () => {
+    mockRepository.findById.mockResolvedValue(undefined);
+
+    await expect(getMembership("non-existent-id")).rejects.toThrow("Membership not found");
+  });
+});
+
+describe("joinCommunity", () => {
+  beforeEach(() => {
+    mockRepository.findByProfileAndCommunity.mockReset();
+    mockRepository.create.mockReset();
+  });
+
+  it("creates membership with active status for public community", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(undefined);
+    mockRepository.create.mockResolvedValue({ ...mockMembership, status: "active" });
+
+    const result = await joinCommunity(
+      mockMembership.profileId,
+      mockMembership.communityId,
+      "public",
+    );
+
+    expect(result.status).toBe("active");
+    expect(mockRepository.create).toHaveBeenCalledWith({
+      communityId: mockMembership.communityId,
+      profileId: mockMembership.profileId,
+      role: "member",
+      status: "active",
+    });
+  });
+
+  it("creates membership with pending status for private community", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(undefined);
+    mockRepository.create.mockResolvedValue({ ...mockMembership, status: "pending" });
+
+    await joinCommunity(mockMembership.profileId, mockMembership.communityId, "private");
+
+    expect(mockRepository.create).toHaveBeenCalledWith({
+      communityId: mockMembership.communityId,
+      profileId: mockMembership.profileId,
+      role: "member",
+      status: "pending",
+    });
+  });
+
+  it("throws AlreadyMemberError when already a member", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(mockMembership);
+
+    await expect(
+      joinCommunity(mockMembership.profileId, mockMembership.communityId, "public"),
+    ).rejects.toThrow("Already a member");
+  });
+});
+
+describe("leaveCommunity", () => {
+  beforeEach(() => {
+    mockRepository.findByProfileAndCommunity.mockReset();
+    mockRepository.deleteById.mockReset();
+  });
+
+  it("deletes membership when user is a member", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(mockMembership);
+    mockRepository.deleteById.mockResolvedValue(true);
+
+    await leaveCommunity(mockMembership.profileId, mockMembership.communityId);
+
+    expect(mockRepository.deleteById).toHaveBeenCalledWith(mockMembership.membershipId);
+  });
+
+  it("throws NotMemberError when not a member", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(undefined);
+
+    await expect(leaveCommunity("non-member", mockMembership.communityId)).rejects.toThrow(
+      "Not a member",
+    );
+  });
+
+  it("throws OwnerCannotLeaveError when user is owner", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(ownerMembership);
+
+    await expect(
+      leaveCommunity(ownerMembership.profileId, ownerMembership.communityId),
+    ).rejects.toThrow("Owner cannot leave");
+  });
+});
+
+describe("updateMembership", () => {
+  beforeEach(() => {
+    mockRepository.findByProfileAndCommunity.mockReset();
+    mockRepository.findById.mockReset();
+    mockRepository.update.mockReset();
+  });
+
+  it("updates membership when actor has sufficient permissions", async () => {
+    const updatedMembership = { ...mockMembership, role: "moderator" as const };
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(adminMembership);
+    mockRepository.findById.mockResolvedValue(mockMembership);
+    mockRepository.update.mockResolvedValue(updatedMembership);
+
+    const result = await updateMembership(
+      mockMembership.membershipId,
+      { role: "moderator" },
+      adminMembership.profileId,
+      mockMembership.communityId,
+    );
+
+    expect(result.role).toBe("moderator");
+  });
+
+  it("throws InsufficientPermissionsError when actor is not active member", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(undefined);
+
+    await expect(
+      updateMembership(
+        mockMembership.membershipId,
+        { role: "moderator" },
+        "non-member",
+        mockMembership.communityId,
+      ),
+    ).rejects.toThrow("Insufficient permissions");
+  });
+
+  it("throws CannotModifyOwnerError when trying to modify owner", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(adminMembership);
+    mockRepository.findById.mockResolvedValue(ownerMembership);
+
+    await expect(
+      updateMembership(
+        ownerMembership.membershipId,
+        { status: "banned" },
+        adminMembership.profileId,
+        mockMembership.communityId,
+      ),
+    ).rejects.toThrow("Cannot modify the community owner");
+  });
+
+  it("throws InsufficientPermissionsError when actor cannot manage target role", async () => {
+    // Admin trying to modify co_owner
+    const coOwnerMembership = { ...mockMembership, role: "co_owner" as const };
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(adminMembership);
+    mockRepository.findById.mockResolvedValue(coOwnerMembership);
+
+    await expect(
+      updateMembership(
+        coOwnerMembership.membershipId,
+        { status: "banned" },
+        adminMembership.profileId,
+        mockMembership.communityId,
+      ),
+    ).rejects.toThrow("Insufficient permissions");
+  });
+
+  it("throws InvalidRoleAssignmentError when trying to assign role >= own", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(adminMembership);
+    mockRepository.findById.mockResolvedValue(mockMembership);
+
+    await expect(
+      updateMembership(
+        mockMembership.membershipId,
+        { role: "admin" },
+        adminMembership.profileId,
+        mockMembership.communityId,
+      ),
+    ).rejects.toThrow("Cannot assign role");
+  });
+});
+
+describe("removeMember", () => {
+  beforeEach(() => {
+    mockRepository.findByProfileAndCommunity.mockReset();
+    mockRepository.findById.mockReset();
+    mockRepository.deleteById.mockReset();
+  });
+
+  it("removes member when actor has permissions", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(adminMembership);
+    mockRepository.findById.mockResolvedValue(mockMembership);
+    mockRepository.deleteById.mockResolvedValue(true);
+
+    await removeMember(
+      mockMembership.membershipId,
+      adminMembership.profileId,
+      mockMembership.communityId,
+    );
+
+    expect(mockRepository.deleteById).toHaveBeenCalledWith(mockMembership.membershipId);
+  });
+
+  it("throws CannotModifyOwnerError when trying to remove owner", async () => {
+    mockRepository.findByProfileAndCommunity.mockResolvedValue(adminMembership);
+    mockRepository.findById.mockResolvedValue(ownerMembership);
+
+    await expect(
+      removeMember(
+        ownerMembership.membershipId,
+        adminMembership.profileId,
+        mockMembership.communityId,
+      ),
+    ).rejects.toThrow("Cannot modify the community owner");
+  });
+});
+
+describe("isMember", () => {
+  beforeEach(() => {
+    mockRepository.membershipExists.mockReset();
+  });
+
+  it("returns true when membership exists", async () => {
+    mockRepository.membershipExists.mockResolvedValue(true);
+
+    const result = await isMember(mockMembership.profileId, mockMembership.communityId);
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false when membership does not exist", async () => {
+    mockRepository.membershipExists.mockResolvedValue(false);
+
+    const result = await isMember("non-member", mockMembership.communityId);
+
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the memberships feature as a complete vertical slice following the established profiles pattern. This enables users to join/leave communities and provides role-based member management for community admins.

## Changes

### Database Schema
- Add `community_role` enum with 5-tier hierarchy: `owner > co_owner > admin > moderator > member`
- Add `membership_status` enum: `active | pending | banned`
- Add `memberships` table with foreign keys to communities and profiles

### Feature Implementation
- **models.ts**: Type definitions using Drizzle's InferSelectModel/InferInsertModel
- **schemas.ts**: Zod validation schemas, role constants, and ROLE_HIERARCHY
- **errors.ts**: 7 error classes with proper HTTP status codes
- **permissions.ts**: Role hierarchy helper functions (canManageRole, canAssignRole, etc.)
- **repository.ts**: Database operations (CRUD, queries by community/profile)
- **service.ts**: Business logic with permission enforcement
- **index.ts**: Public API exports (repository hidden)

### API Routes
- `GET /api/communities/[slug]/members` - List all members
- `POST /api/communities/[slug]/members` - Join community
- `GET /api/communities/[slug]/members/me` - Get own membership
- `DELETE /api/communities/[slug]/members/me` - Leave community
- `PATCH /api/communities/[slug]/members/[profileId]` - Update member role/status
- `DELETE /api/communities/[slug]/members/[profileId]` - Remove member

### Testing
- 71 unit tests covering errors, schemas, permissions, and service
- All tests pass with good coverage

## Testing

- [x] `bun run lint` - No errors
- [x] `npx tsc --noEmit` - No type errors
- [x] `bun test` - 286 tests pass
- [x] `bun run build` - Build succeeds

## Notes

This PR implements the API layer only (per plan scope). UI pages for member list and management are planned as a separate task.

Plan Reference: `.agents/plans/memberships.plan.md`